### PR TITLE
Add MiniMax vision provider

### DIFF
--- a/src/watch_skill/config.py
+++ b/src/watch_skill/config.py
@@ -75,6 +75,8 @@ class Settings(BaseSettings):
     openai_api_key: SecretStr | None = None
     gemini_api_key: SecretStr | None = None
     groq_api_key: SecretStr | None = None
+    minimax_api_key: SecretStr | None = None
+    minimax_base_url: str = "https://api.minimax.io/v1"
     openrouter_api_key: SecretStr | None = None
     ollama_base_url: str = "http://127.0.0.1:11434"
     ollama_num_ctx: int = Field(

--- a/src/watch_skill/health/vision_setup.py
+++ b/src/watch_skill/health/vision_setup.py
@@ -40,6 +40,11 @@ CLOUD_PROVIDER_DEFAULTS: dict[str, tuple[str, str, str]] = {
         "google/gemini-3.5-flash",
         "anthropic/claude-sonnet-5",
     ),
+    "minimax": ("WATCHSKILL_MINIMAX_API_KEY", "MiniMax-M3", "MiniMax-M3"),
+}
+
+CLOUD_PROVIDER_BASE_URLS: dict[str, str] = {
+    "minimax": "https://api.minimax.io/v1",
 }
 
 # Local vision models by machine size. qwen2.5vl:3b reads on-screen text well
@@ -151,16 +156,16 @@ def configure_cloud(
             fix=f"set {defaults[0]} or pass --api-key",
         )
     key_name, default_cheap, default_strong = defaults
-    return set_env_vars(
-        {
+    updates = {
             key_name: api_key.strip(),
             "WATCHSKILL_VISION_CHEAP_PROVIDER": provider,
             "WATCHSKILL_VISION_CHEAP_MODEL": cheap_model or default_cheap,
             "WATCHSKILL_VISION_STRONG_PROVIDER": provider,
             "WATCHSKILL_VISION_STRONG_MODEL": strong_model or default_strong,
-        },
-        path,
-    )
+    }
+    if provider in CLOUD_PROVIDER_BASE_URLS:
+        updates[f"WATCHSKILL_{provider.upper()}_BASE_URL"] = CLOUD_PROVIDER_BASE_URLS[provider]
+    return set_env_vars(updates, path)
 
 
 # Compatibility helper retained for callers that already use it directly.

--- a/src/watch_skill/vision/client.py
+++ b/src/watch_skill/vision/client.py
@@ -91,6 +91,13 @@ def _openrouter_request(model: str, key: str, prompt: str, images: list[Path]) -
     return PROVIDERS["openrouter"].endpoint, headers, body
 
 
+def _minimax_request(model: str, key: str, prompt: str, images: list[Path]) -> tuple[str, dict, dict]:
+    _, headers, body = _openai_request(model, key, prompt, images)
+    settings = get_settings()
+    endpoint = PROVIDERS["minimax"].endpoint.format(base=settings.minimax_base_url.rstrip("/"))
+    return endpoint, headers, body
+
+
 def _gemini_request(model: str, key: str, prompt: str, images: list[Path]) -> tuple[str, dict, dict]:
     parts: list[dict[str, Any]] = [
         {"inline_data": {"mime_type": _media_type(p), "data": _b64(p)}} for p in images
@@ -136,6 +143,7 @@ _BUILDERS: dict[str, tuple[Callable, Callable]] = {
     "anthropic": (_anthropic_request, _anthropic_extract),
     "openai": (_openai_request, _openai_extract),
     "openrouter": (_openrouter_request, _openai_extract),
+    "minimax": (_minimax_request, _openai_extract),
     "gemini": (_gemini_request, _gemini_extract),
     "ollama": (_ollama_request, _ollama_extract),
 }

--- a/src/watch_skill/vision/prices.json
+++ b/src/watch_skill/vision/prices.json
@@ -1,5 +1,5 @@
 {
-  "as_of": "2026-07-11",
+  "as_of": "2026-07-23",
   "unit": "USD per million input tokens",
   "note": "Deliberately conservative (over-estimates) - these feed the cost guard and the stats --cost estimate, not billing. Audit trail: update this file, not code, when a provider reprices; the date above must move with any edit.",
   "usd_per_mtok": {
@@ -11,6 +11,8 @@
     "google/gemini-3.5-flash": 1.5,
     "qwen/qwen2.5-vl-72b-instruct:free": 0.0,
     "anthropic/claude-sonnet-5": 3.0,
+    "MiniMax-M3": 0.6,
+    "MiniMax-M2.7": 0.3,
     "moondream": 0.0,
     "qwen2.5vl:3b": 0.0
   }

--- a/src/watch_skill/vision/registry.py
+++ b/src/watch_skill/vision/registry.py
@@ -47,6 +47,12 @@ PROVIDERS: dict[str, ProviderSpec] = {
         key_setting="openrouter_api_key",
         default_price_per_mtok=3.0,
     ),
+    "minimax": ProviderSpec(
+        name="minimax",
+        endpoint="{base}/chat/completions",
+        key_setting="minimax_api_key",
+        default_price_per_mtok=0.6,
+    ),
     "ollama": ProviderSpec(
         name="ollama",
         endpoint="{base}/api/chat",  # base from settings.ollama_base_url

--- a/tests/health/test_vision_setup.py
+++ b/tests/health/test_vision_setup.py
@@ -71,6 +71,16 @@ def test_configure_cloud_accepts_separate_model_tiers(tmp_path: Path) -> None:
     assert "WATCHSKILL_VISION_STRONG_MODEL=strong-vision" in text
 
 
+def test_configure_minimax_writes_base_url(tmp_path: Path) -> None:
+    env = tmp_path / ".env"
+    vs.configure_cloud("minimax", "secret", path=env)
+    text = env.read_text(encoding="utf-8")
+    assert "WATCHSKILL_MINIMAX_API_KEY=secret" in text
+    assert "WATCHSKILL_MINIMAX_BASE_URL=https://api.minimax.io/v1" in text
+    assert "WATCHSKILL_VISION_CHEAP_PROVIDER=minimax" in text
+    assert "WATCHSKILL_VISION_STRONG_MODEL=MiniMax-M3" in text
+
+
 def test_configure_ollama_pins_batch_size_one(tmp_path: Path) -> None:
     env = tmp_path / ".env"
     vs.configure_ollama(model="llava:7b", path=env)

--- a/tests/vision/test_vision.py
+++ b/tests/vision/test_vision.py
@@ -186,6 +186,34 @@ def test_openrouter_free_model_costs_nothing() -> None:
     assert price_for("openrouter", "qwen/qwen2.5-vl-72b-instruct:free") == 0.0
 
 
+def test_minimax_wire_format_and_regional_base_url(
+    frame: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WATCHSKILL_MINIMAX_API_KEY", "mm-test-key")
+    monkeypatch.setenv("WATCHSKILL_MINIMAX_BASE_URL", "https://api.minimaxi.com/v1")
+    reset_settings()
+    capture: dict = {}
+    _mock_post(
+        monkeypatch,
+        {"choices": [{"message": {"content": "a red frame via minimax"}}]},
+        capture,
+    )
+
+    out = VisionClient("minimax", "MiniMax-M3").generate("describe", [frame])
+    assert out == "a red frame via minimax"
+    assert capture["url"] == "https://api.minimaxi.com/v1/chat/completions"
+    assert capture["headers"]["Authorization"] == "Bearer mm-test-key"
+    assert capture["body"]["model"] == "MiniMax-M3"
+    assert capture["body"]["messages"][0]["content"][0]["type"] == "image_url"
+
+
+def test_minimax_prices_are_registered() -> None:
+    from watch_skill.vision.registry import price_for
+
+    assert price_for("minimax", "MiniMax-M3") == 0.6
+    assert price_for("minimax", "MiniMax-M2.7") == 0.3
+
+
 def test_describe_frames_batches_by_setting(
     frame: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
Reason: Add MiniMax as a direct vision provider for frame-based video understanding.

Changes:
- Adds MiniMax API key and base URL settings.
- Registers the MiniMax provider and MiniMax-M3/MiniMax-M2.7 price entries.
- Routes MiniMax vision calls through the OpenAI-compatible chat completions payload.
- Adds setup defaults and focused coverage for regional endpoint configuration.

Checks:
- `uv run --group dev pytest tests/vision/test_vision.py tests/health/test_vision_setup.py`
- `uv run --group dev ruff check src/watch_skill/config.py src/watch_skill/vision/registry.py src/watch_skill/vision/client.py src/watch_skill/health/vision_setup.py tests/vision/test_vision.py tests/health/test_vision_setup.py`
- `git diff --check`
- `python3 -m compileall -q src/watch_skill tests/vision/test_vision.py tests/health/test_vision_setup.py`
