### PR TITLE
feat(vision): add a `local` provider for OpenAI-compatible gateways

### DIFF
--- a/src/watch_skill/config.py
+++ b/src/watch_skill/config.py
@@ -77,6 +77,13 @@ class Settings(BaseSettings):
     groq_api_key: SecretStr | None = None
     openrouter_api_key: SecretStr | None = None
     ollama_base_url: str = "http://127.0.0.1:11434"
+    local_openai_base_url: str = Field(
+        default="http://127.0.0.1:4000",
+        description="Base URL of an OpenAI-compatible gateway served by the "
+        "`local` provider (LiteLLM, LM Studio, vLLM, Jan, or any local router). "
+        "Keyless: the gateway owns the upstream credentials, so no "
+        "frame-bearing request carries a secret out of this process.",
+    )
     ollama_num_ctx: int = Field(
         default=2048,
         description="Context window for local Ollama vision calls. The compute "

--- a/src/watch_skill/vision/client.py
+++ b/src/watch_skill/vision/client.py
@@ -132,12 +132,26 @@ def _ollama_extract(data: dict) -> str:
     return data.get("message", {}).get("content", "")
 
 
+def _local_request(model: str, key: str, prompt: str, images: list[Path]) -> tuple[str, dict, dict]:
+    # A local OpenAI-compatible gateway (LiteLLM, LM Studio, vLLM, ...). Same wire format
+    # as `openai`, different endpoint, and no key: the gateway holds the
+    # upstream credentials itself. Auth is still sent because some gateways
+    # reject a request with no Authorization header at all.
+    settings = get_settings()
+    endpoint = PROVIDERS["local"].endpoint.format(
+        base=settings.local_openai_base_url.rstrip("/")
+    )
+    _, headers, body = _openai_request(model, key or "local", prompt, images)
+    return endpoint, headers, body
+
+
 _BUILDERS: dict[str, tuple[Callable, Callable]] = {
     "anthropic": (_anthropic_request, _anthropic_extract),
     "openai": (_openai_request, _openai_extract),
     "openrouter": (_openrouter_request, _openai_extract),
     "gemini": (_gemini_request, _gemini_extract),
     "ollama": (_ollama_request, _ollama_extract),
+    "local": (_local_request, _openai_extract),
 }
 
 

--- a/src/watch_skill/vision/registry.py
+++ b/src/watch_skill/vision/registry.py
@@ -53,6 +53,13 @@ PROVIDERS: dict[str, ProviderSpec] = {
         key_setting=None,
         default_price_per_mtok=0.0,
     ),
+    "local": ProviderSpec(
+        name="local",
+        # base from settings.local_openai_base_url; OpenAI wire format
+        endpoint="{base}/v1/chat/completions",
+        key_setting=None,
+        default_price_per_mtok=0.0,
+    ),
 }
 
 # Model-specific price overrides live in prices.json next to this file —

--- a/tests/vision/test_vision.py
+++ b/tests/vision/test_vision.py
@@ -77,6 +77,20 @@ def test_ollama_needs_no_key(frame: Path, monkeypatch: pytest.MonkeyPatch) -> No
     assert "11434" in capture["url"]
 
 
+def test_local_gateway_needs_no_key(frame: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("WATCHSKILL_LOCAL_OPENAI_BASE_URL", "http://127.0.0.1:9999/")
+    reset_settings()
+    capture: dict = {}
+    _mock_post(monkeypatch, {"choices": [{"message": {"content": "gateway answer"}}]}, capture)
+    out = VisionClient("local", "some/vision-model").generate("describe", [frame])
+    assert out == "gateway answer"
+    # OpenAI wire format on the gateway's own endpoint, trailing slash stripped.
+    assert capture["url"] == "http://127.0.0.1:9999/v1/chat/completions"
+    assert capture["body"]["messages"][0]["content"][0]["type"] == "image_url"
+    # Keyless: the gateway owns the upstream credential, no secret leaves here.
+    assert capture["headers"]["Authorization"] == "Bearer local"
+
+
 def test_missing_key_is_structured(frame: Path) -> None:
     with pytest.raises(VisionError) as excinfo:
         VisionClient("anthropic", "claude-sonnet-5").generate("x", [frame])


### PR DESCRIPTION
## Problem

Every vision endpoint in `registry.py` is hardcoded. Only `ollama` takes a base URL, and it speaks `/api/chat` rather than `/v1/chat/completions` — so an OpenAI-compatible gateway running on localhost cannot be reached at all today.

That covers a real and growing case. LiteLLM, LM Studio, vLLM, Jan and per-user routers all expose the OpenAI chat-completions shape on a local port. Users who already hold upstream credentials there currently have to re-enter a key into Watch Skill, or go without visual synthesis entirely.

## What this adds

- `config.py` — `local_openai_base_url`, defaulting to LiteLLM's `127.0.0.1:4000`
- `registry.py` — a `local` provider, endpoint `{base}/v1/chat/completions`, keyless
- `client.py` — `_local_request`, reusing the existing `_openai_request` body builder

28 lines of source, no new dependency, no new abstraction. It follows the shape the registry already documents as "adding a model is an entry, not a class".

Keyless by design, mirroring how `ollama` is treated: the gateway owns the upstream credentials, so no frame-bearing request carries a secret out of the process. `Authorization: Bearer local` is still sent, because some gateways reject a request with no auth header at all.

## What this does not change

Defaults are untouched. `vision_cheap_provider` and `vision_strong_provider` still resolve to `anthropic`. Opting in is environment-only:

```
WATCHSKILL_VISION_CHEAP_PROVIDER=local
WATCHSKILL_VISION_STRONG_PROVIDER=local
WATCHSKILL_LOCAL_OPENAI_BASE_URL=http://127.0.0.1:4000
```

## Deliberately out of scope

`setup-vision --provider local` still errors with `Unknown provider`, because the CLI validates its own list and I kept this PR to the provider itself. Happy to add the CLI branch and a `configure_local` in `vision_setup` as a follow-up if you want it.

## Testing

New test `test_local_gateway_needs_no_key` in `tests/vision/test_vision.py`, following the existing `test_ollama_needs_no_key` shape. It asserts the resolved endpoint (including trailing-slash stripping), the OpenAI wire format, and that no real credential is sent.

`tests/vision/` passes, 19 tests. Also verified end to end against a live local gateway with a Gemini Flash model behind it:

- `watch-skill watch` on a 19s YouTube video: frames, OCR, transcript, index
- `watch-skill ask` returned `verified: true` at confidence 0.69, where the same question with no provider configured refused at 0.33
- `watch-skill loop start` on a static page passed at iteration 0, score 100, verdict `pass`

One note unrelated to this change: `tests/loop/test_capture.py::test_capture_local_page_records_video` and `::test_capture_with_interaction_script` fail on a clean `origin/main` checkout on macOS 27 / Python 3.13 too, so they are not caused by this PR. Happy to open a separate issue with the traceback if it is useful.