### PR TITLE
fix(localize): stop losing Portuguese to its neighbours

### DIFF
--- a/src/watch_skill/answer/localize.py
+++ b/src/watch_skill/answer/localize.py
@@ -58,7 +58,8 @@ _LATIN_STOP = {
     "de": {"der", "die", "das", "und", "wann", "wie", "wo", "was", "ein", "eine",
            "zeigt", "warum", "bildschirm", "erscheint", "video"},
     "pt": {"os", "as", "que", "quando", "onde", "como", "para", "uma", "aparece",
-           "vídeo", "mostra", "tela", "está"},
+           "vídeo", "mostra", "tela", "está", "é", "não", "são", "qual", "quais",
+           "do", "da", "dos", "das", "você", "ele", "ela", "isso", "sobre", "tem"},
     "it": {"il", "le", "che", "di", "quando", "dove", "come", "per", "una", "mostra",
            "video", "appare", "schermo"},
     "en": {"the", "what", "when", "where", "how", "why", "is", "does", "show",
@@ -80,9 +81,22 @@ def detect_lang(text: str) -> str:
         return max(counts, key=counts.get)  # type: ignore[arg-type]
 
     tokens = {t.strip(".,!?¿¡:;\"'()").lower() for t in text.split()}
-    scores = {lang: len(tokens & words) for lang, words in _LATIN_STOP.items()}
-    best = max(scores, key=scores.get)  # type: ignore[arg-type]
-    return best if scores[best] > 0 else "en"
+    hits = {lang: tokens & words for lang, words in _LATIN_STOP.items()}
+    top = max(len(h) for h in hits.values())
+    if top == 0:
+        return "en"
+    tied = [lang for lang, h in hits.items() if len(h) == top]
+    if len(tied) == 1:
+        return tied[0]
+    # A tie on raw count used to be settled by dict order, which quietly handed
+    # every draw to whichever language was declared first. Prefer the language
+    # whose matched words no other tied language claims — a word only Portuguese
+    # uses is worth more than one Portuguese and Italian share.
+    def _unshared(lang: str) -> int:
+        others = set().union(*(hits[other] for other in tied if other != lang))
+        return len(hits[lang] - others)
+
+    return max(tied, key=_unshared)
 
 
 def is_rtl(lang: str) -> bool:

--- a/tests/answer/test_localize.py
+++ b/tests/answer/test_localize.py
@@ -39,6 +39,8 @@ LRI, PDI = "⁦", "⁩"
     ("¿Cuándo aparece la pantalla de advertencia?", "es"),
     ("Quand l'écran d'avertissement apparaît-il ?", "fr"),
     ("Wann erscheint der Warnbildschirm?", "de"),
+    ("Quando appare la schermata di avviso?", "it"),
+    ("Quando aparece a tela de aviso?", "pt"),
     ("When does the warning screen appear?", "en"),
 ])
 def test_detect_lang(text: str, expected: str) -> None:
@@ -47,6 +49,26 @@ def test_detect_lang(text: str, expected: str) -> None:
 
 def test_detect_lang_defaults_to_english() -> None:
     assert detect_lang("zzz qqq") == "en"
+
+
+@pytest.mark.parametrize("text", [
+    "Qual é o assunto do vídeo?",
+    "Do que trata a primeira parte do video?",
+    "Quais são os três pontos principais?",
+    "Me mostra o momento em que ele abre o terminal",
+])
+def test_portuguese_is_not_lost_to_its_neighbours(text: str) -> None:
+    """Portuguese shares most of its function words with Spanish, French and
+    Italian, so a short question used to draw — and a draw was decided by
+    declaration order, never by evidence."""
+    assert detect_lang(text) == "pt"
+
+
+def test_tie_prefers_the_language_with_unshared_words() -> None:
+    """`mostra` is Portuguese and Italian; `ele` is only Portuguese. The tie
+    breaks on the word nobody else claims, not on dict order."""
+    assert detect_lang("ele mostra") == "pt"
+    assert detect_lang("appare lo schermo") == "it"
 
 
 # ---- honest floor localized ------------------------------------------------


### PR DESCRIPTION
## The bug

`detect_lang` decides which language the engine speaks — and it feeds
`answer_language_directive`, the instruction handed to the vision model. When it
guesses wrong, a question asked in Portuguese can be paid for and answered in
French.

Portuguese loses for two reasons that compound:

1. **Its stopword set is missing the words only Portuguese uses.** `pt` has no
   `é`, `não`, `qual`, `quais`, `do`, `da`, `você`, `ele` — so a short question
   matches on words it *shares* with Spanish, French or Italian, and ties.
2. **A tie is settled by declaration order.** `max()` over a dict returns the
   first key at the maximum, and the order is `es, fr, de, pt, it, en`.
   Portuguese sits fourth, so it loses every draw it enters.

Measured on nine natural Portuguese questions before the change: **7 correct,
2 wrong**.

```
ERRO -> es  | Qual é o assunto do vídeo?
        es=1 ['vídeo'] · pt=1 ['vídeo']            <- tie, es wins on order
ERRO -> fr  | Do que trata a primeira parte do video?
        fr=1 ['que'] · de=1 ['video'] · pt=1 ['que'] · it=1 ['video'] · en=1 ['video']
```

## The fix

- Add the unshared Portuguese function words to `_LATIN_STOP["pt"]`.
- Break ties on **words no other tied language claims**, instead of on
  declaration order. A word only Portuguese uses now outweighs one that
  Portuguese and Italian share. The rule is language-agnostic — any language
  that draws benefits, and the existing single-winner path is untouched.

Nothing else changes: script detection, the English default, and the fallback
to `"en"` when nothing matches all behave exactly as before.

## Verification

- The nine Portuguese questions: **7/9 → 9/9**.
- A 24-case cross-language check (the 11 cases already in the suite plus two
  extra sentences each for es/fr/de/it/en/pt), old code vs new: **no language
  regressed**; the only changed verdict is the Portuguese one that used to
  return `es`.
- Full suite: **624 passed, 89 skipped**.

## Tests added

The suite had no Portuguese case at all (and none for Italian), which is why
this went unnoticed. This PR adds:

- `it` and `pt` rows to the existing `test_detect_lang` parametrization;
- `test_portuguese_is_not_lost_to_its_neighbours` — the four questions above;
- `test_tie_prefers_the_language_with_unshared_words` — pins the new tie-break
  in both directions (`ele mostra` → pt, `appare lo schermo` → it), so a future
  reordering of the dict can't silently bring the bias back.

---

Found while using watch-skill on Portuguese-language video in day-to-day work —
the tool is excellent, and this was the one place it consistently misread us.
