### PR TITLE
fix(setup): restore agent config after a failed write

### DIFF
--- a/src/watch_skill/health/agents_setup.py
+++ b/src/watch_skill/health/agents_setup.py
@@ -5,6 +5,7 @@ on this machine and offers to register the MCP server in each one — with a
 timestamped backup of any file it touches, and surgical merges that never
 drop existing keys.
 """
+
 from __future__ import annotations
 
 import json
@@ -20,11 +21,11 @@ from pathlib import Path
 class AgentTarget:
     """One configurable agent installation found on this machine."""
 
-    key: str            # claude-code | claude-desktop | cursor | codex | windsurf | cline | gemini
+    key: str  # claude-code | claude-desktop | cursor | codex | windsurf | cline | gemini
     label: str
     config_path: Path
-    kind: str           # json-mcpservers | toml-codex
-    detected: bool      # was the agent itself found (not just its config)?
+    kind: str  # json-mcpservers | toml-codex
+    detected: bool  # was the agent itself found (not just its config)?
     configured: bool = False  # already has an watch-skill entry
 
 
@@ -55,30 +56,47 @@ def detect_agents() -> list[AgentTarget]:
     mac_support = home / "Library" / "Application Support"
     candidates = [
         AgentTarget(
-            "claude-code", "Claude Code", home / ".claude.json", "json-mcpservers",
+            "claude-code",
+            "Claude Code",
+            home / ".claude.json",
+            "json-mcpservers",
             detected=bool(shutil.which("claude")) or (home / ".claude.json").is_file(),
         ),
         AgentTarget(
-            "claude-desktop", "Claude Desktop",
-            (appdata if sys.platform == "win32" else mac_support) / "Claude" / "claude_desktop_config.json",
+            "claude-desktop",
+            "Claude Desktop",
+            (appdata if sys.platform == "win32" else mac_support)
+            / "Claude"
+            / "claude_desktop_config.json",
             "json-mcpservers",
             detected=((appdata if sys.platform == "win32" else mac_support) / "Claude").is_dir(),
         ),
         AgentTarget(
-            "cursor", "Cursor", home / ".cursor" / "mcp.json", "json-mcpservers",
+            "cursor",
+            "Cursor",
+            home / ".cursor" / "mcp.json",
+            "json-mcpservers",
             detected=(home / ".cursor").is_dir() or bool(shutil.which("cursor")),
         ),
         AgentTarget(
-            "codex", "Codex CLI", home / ".codex" / "config.toml", "toml-codex",
+            "codex",
+            "Codex CLI",
+            home / ".codex" / "config.toml",
+            "toml-codex",
             detected=(home / ".codex").is_dir() or bool(shutil.which("codex")),
         ),
         AgentTarget(
-            "windsurf", "Windsurf", home / ".codeium" / "windsurf" / "mcp_config.json",
+            "windsurf",
+            "Windsurf",
+            home / ".codeium" / "windsurf" / "mcp_config.json",
             "json-mcpservers",
             detected=(home / ".codeium" / "windsurf").is_dir(),
         ),
         AgentTarget(
-            "gemini", "Gemini CLI", home / ".gemini" / "settings.json", "json-mcpservers",
+            "gemini",
+            "Gemini CLI",
+            home / ".gemini" / "settings.json",
+            "json-mcpservers",
             detected=(home / ".gemini").is_dir() or bool(shutil.which("gemini")),
         ),
     ]
@@ -121,16 +139,12 @@ def _write_toml_codex(path: Path, command: str, args: list[str]) -> None:
     if "[mcp_servers.watch-skill]" in text:
         return
     args_toml = ", ".join(json.dumps(a) for a in args)
-    block = (
-        f'\n[mcp_servers.watch-skill]\ncommand = "{command}"\nargs = [{args_toml}]\n'
-    )
+    block = f'\n[mcp_servers.watch-skill]\ncommand = "{command}"\nargs = [{args_toml}]\n'
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(text + block, encoding="utf-8")
 
 
-def configure_agent(
-    target: AgentTarget, project_dir: Path | None = None
-) -> tuple[bool, str]:
+def configure_agent(target: AgentTarget, project_dir: Path | None = None) -> tuple[bool, str]:
     """Write the watch-skill MCP entry into one agent's config.
 
     Returns (changed, human message). Existing files are backed up first;
@@ -145,7 +159,46 @@ def configure_agent(
             _write_json_mcpservers(target.config_path, command, args)
         else:
             _write_toml_codex(target.config_path, command, args)
-    except (OSError, json.JSONDecodeError) as exc:
+    except json.JSONDecodeError as exc:
+        # Raised while reading the existing config, before any write: the
+        # file genuinely is untouched.
         return False, f"{target.label}: FAILED to write ({exc}) — config untouched"
+    except OSError as exc:
+        # A write that raised may still have truncated or replaced the file,
+        # so roll back to the pre-call bytes instead of claiming untouched.
+        restored = _restore_from_backup(target.config_path, backup)
+        if backup is None:
+            if restored:
+                return (
+                    False,
+                    f"{target.label}: FAILED to write ({exc}) — partial new config removed",
+                )
+            return (
+                False,
+                f"{target.label}: FAILED to write ({exc}) — could not remove partial config at {target.config_path}; delete it manually",
+            )
+        if restored:
+            return (
+                False,
+                f"{target.label}: FAILED to write ({exc}) — restored pre-call config from {backup.name}",
+            )
+        return (
+            False,
+            f"{target.label}: FAILED to write ({exc}) — RESTORE FAILED; recover manually from {backup.name}",
+        )
     note = f" (backup: {backup.name})" if backup else ""
     return True, f"{target.label}: configured -> {target.config_path}{note}"
+
+
+def _restore_from_backup(path: Path, backup: Path | None) -> bool:
+    """Best-effort rollback after a failed write. A config that did not exist
+    before the call must not be left behind as a partial file. Returns whether
+    the pre-call state was recovered."""
+    try:
+        if backup is None:
+            path.unlink(missing_ok=True)
+        else:
+            shutil.copy2(backup, path)
+    except OSError:
+        return False
+    return True

--- a/tests/health/test_agents_setup.py
+++ b/tests/health/test_agents_setup.py
@@ -1,0 +1,134 @@
+"""Failure-path contract for configure_agent: a failed write must leave the
+agent's config exactly as it was before the call (or absent), and the message
+must say what actually happened — not claim "config untouched" over a
+truncated file (issue #17).
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+from watch_skill.health.agents_setup import AgentTarget, configure_agent
+
+
+def _target(config_path: Path) -> AgentTarget:
+    return AgentTarget(
+        key="claude-code",
+        label="Claude Code",
+        config_path=config_path,
+        kind="json-mcpservers",
+        detected=True,
+    )
+
+
+def _inject_partial_write(monkeypatch: pytest.MonkeyPatch, partial: str) -> None:
+    """Replace Path.write_text with one that writes `partial` to the real path
+    and then raises, simulating a mid-write failure. Uses open() directly so
+    the injected writer does not recurse through the patch."""
+
+    def faulty(self: Path, data: str, *args: object, **kwargs: object) -> int:
+        self.parent.mkdir(parents=True, exist_ok=True)
+        with open(self, "w", encoding="utf-8") as fh:
+            fh.write(partial)
+        raise OSError("injected write failure")
+
+    monkeypatch.setattr(Path, "write_text", faulty)
+
+
+def test_configure_agent_restores_existing_config_after_partial_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = tmp_path / ".claude.json"
+    original = json.dumps(
+        {"mcpServers": {"other-agent": {"command": "x"}}, "unrelated": True},
+        indent=2,
+    )
+    config.write_text(original, encoding="utf-8")
+    _inject_partial_write(monkeypatch, '{"truncated":')
+
+    changed, message = configure_agent(_target(config))
+
+    assert changed is False
+    assert "restored" in message.lower()
+    # Public postcondition: the live file equals its pre-call bytes.
+    assert config.read_text(encoding="utf-8") == original
+
+
+def test_configure_agent_restores_toml_config_after_partial_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = tmp_path / "config.toml"
+    original = '[mcp_servers.other]\ncommand = "x"\n'
+    config.write_text(original, encoding="utf-8")
+    target = AgentTarget(
+        key="codex", label="Codex CLI", config_path=config, kind="toml-codex", detected=True
+    )
+    _inject_partial_write(monkeypatch, "[mcp_servers.watch")
+
+    changed, message = configure_agent(target)
+
+    assert changed is False
+    assert "restored" in message.lower()
+    assert config.read_text(encoding="utf-8") == original
+
+
+def test_configure_agent_removes_partial_new_config_after_failed_first_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = tmp_path / ".gemini" / "settings.json"
+    _inject_partial_write(monkeypatch, '{"partial":')
+
+    changed, message = configure_agent(_target(config))
+
+    assert changed is False
+    assert "removed" in message.lower()
+    # A config that did not exist before the call must not be left partial.
+    assert not config.exists()
+
+
+def test_configure_agent_reports_failed_restoration_instead_of_lying(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = tmp_path / ".claude.json"
+    original = '{"keep": true}'
+    config.write_text(original, encoding="utf-8")
+    _inject_partial_write(monkeypatch, '{"truncated":')
+    real_copy2 = shutil.copy2
+
+    def selective_raiser(src, dst, **kwargs):
+        # Fail only the RESTORE direction (backup -> live); the initial
+        # backup creation (live -> backup) must still succeed.
+        if ".backup-" in str(src):
+            raise OSError("injected restore failure")
+        return real_copy2(src, dst, **kwargs)
+
+    monkeypatch.setattr("watch_skill.health.agents_setup.shutil.copy2", selective_raiser)
+
+    changed, message = configure_agent(_target(config))
+
+    assert changed is False
+    assert "restore failed" in message.lower()
+    # The truncated live file is still there; nothing claimed it was fine.
+    assert config.read_text(encoding="utf-8") == '{"truncated":'
+
+
+def _raiser(*args: object, **kwargs: object) -> None:
+    raise OSError("injected restore failure")
+
+
+def test_configure_agent_invalid_json_still_reads_as_untouched(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = tmp_path / ".claude.json"
+    original = "{not valid json"
+    config.write_text(original, encoding="utf-8")
+
+    changed, message = configure_agent(_target(config))
+
+    assert changed is False
+    assert "untouched" in message.lower()
+    assert config.read_text(encoding="utf-8") == original


### PR DESCRIPTION
Fixes #17

## Problem

`configure_agent` reported `config untouched` on any write failure, but a write that raised mid-flight could leave the live file truncated. The issue's repro (fault-injected `Path.write_text` that writes `{"truncated":` then raises) showed: `changed=False`, backup intact with the pre-call bytes, live config truncated, and a message claiming untouched.

## Change

The `OSError` path now rolls back instead of asserting innocence:

- **Backup exists** (config existed before): restore the exact pre-call bytes via the backup; message says `restored pre-call config from <backup>`.
- **No backup** (first-time setup): remove any partial file; message says `partial new config removed` — or, if even removal fails, names the path for manual cleanup.
- **Restore itself fails**: message explicitly says `RESTORE FAILED; recover manually from <backup name>` rather than implying all is well.
- The parse-error path (`json.JSONDecodeError`, raised while *reading* the existing config, before any write) keeps the accurate `config untouched` message.

New `_restore_from_backup(path, backup)` helper centralizes the best-effort rollback.

## Verification

```
pytest tests/health/test_agents_setup.py   # 5 passed
```

Tests assert public postconditions per the issue's suggested contract:
- `restores_existing_config_after_partial_write` — live file byte-for-byte equals pre-call contents
- `restores_toml_config_after_partial_write` — same for the TOML writer
- `removes_partial_new_config_after_failed_first_write` — no partial file survives
- `reports_failed_restoration_instead_of_lying` — rollback failure surfaces as manual-recovery guidance
- `invalid_json_still_reads_as_untouched` — the genuinely-untouched case keeps its message

The first three fail against unpatched code and pass with this change (verified by stashing the source). `ruff check` + `ruff format --check` clean on both files.

---
This change was prepared with AI assistance under human direction and review.
