### PR TITLE
fix(docker): publish the image for a release the workflow token created

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,6 +33,18 @@ on:
       - "Dockerfile"
       - ".github/workflows/docker.yml"
   workflow_dispatch:
+    inputs:
+      version:
+        description: >-
+          The released version to tag the image with, e.g. 1.4.0. Leave empty
+          to build and push only the branch tag.
+        required: false
+        type: string
+      latest:
+        description: Also move `latest` to this image. Only for a stable release.
+        required: false
+        default: false
+        type: boolean
 
 env:
   IMAGE: ghcr.io/${{ github.repository }}
@@ -71,11 +83,22 @@ jobs:
             type=ref,event=branch
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            # `latest` is the released image, so it is set by a release and
-            # never by a branch. A prerelease tag is excluded by the metadata
-            # action's own semver handling, which is why this is expressed as
-            # a release event rather than as "the newest thing we built".
-            type=raw,value=latest,enable=${{ github.event_name == 'release' && github.event.release.prerelease == false }}
+            # The version, when a dispatch names one.
+            #
+            # `release: published` does not reach this workflow when the
+            # release was created by `GITHUB_TOKEN` — GitHub does not raise
+            # workflow events for actions a workflow token took, which is loop
+            # prevention working as designed. `core-v1.4.0` published to PyPI,
+            # completed its Release, and no image was ever pushed for it: the
+            # registry held `main` and a `latest` from some earlier path, and
+            # nothing said so.
+            #
+            # Core's tag is `core-v<version>`, which is not semver, so the
+            # `type=semver` lines above match nothing on that ref either. The
+            # version is therefore passed in rather than derived, and the two
+            # raw tags below are what a dispatch actually publishes.
+            type=raw,value=${{ inputs.version }},enable=${{ inputs.version != '' }}
+            type=raw,value=latest,enable=${{ (github.event_name == 'release' && github.event.release.prerelease == false) || (github.event_name == 'workflow_dispatch' && inputs.latest) }}
 
       - name: Build
         uses: docker/build-push-action@v7

--- a/workspace/tests/workflow-policy.test.mjs
+++ b/workspace/tests/workflow-policy.test.mjs
@@ -272,9 +272,32 @@ describe('merging a branch cannot publish anything', () => {
     // and the wrong one for a project with two release trains.
     assert.ok(!/value=latest,enable=\{\{is_default_branch\}\}/.test(docker),
       'latest must not follow the default branch')
-    assert.match(docker, /value=latest,enable=\$\{\{ github\.event_name == 'release'/)
-    assert.match(docker, /github\.event\.release\.prerelease == false/,
+
+    // The property, not one spelling of it. This asserted the exact
+    // expression, which made a second legitimate way to publish a release
+    // look like a policy violation: `release: published` does not reach this
+    // workflow when the release was created by `GITHUB_TOKEN`, so a dispatch
+    // has to be able to publish one — and the rule that matters is which
+    // triggers may take the tag, not how the condition is written.
+    const latest = docker.split('\n')
+      .filter(line => line.includes('value=latest'))
+      .join('\n')
+    assert.notEqual(latest, '', 'nothing sets latest at all')
+    assert.match(latest, /github\.event_name == 'release'/,
+      'a release must be able to take latest')
+    assert.match(latest, /github\.event\.release\.prerelease == false/,
       'a prerelease must not take latest')
+
+    // Every trigger named in that condition is one a person chose. A branch
+    // push is not, and neither is a pull request.
+    const triggers = [...latest.matchAll(/github\.event_name == '([a-z_]+)'/g)]
+      .map(match => match[1])
+    assert.deepEqual(triggers.filter(name => !['release', 'workflow_dispatch'].includes(name)),
+      [], `latest is reachable from a trigger nobody chose: ${triggers.join(', ')}`)
+    if (triggers.includes('workflow_dispatch')) {
+      assert.match(latest, /inputs\.latest/,
+        'a dispatch may take latest only when it was asked for explicitly')
+    }
   })
 
   test('a branch push still builds the image, so a broken Dockerfile fails early', () => {


### PR DESCRIPTION
`core-v1.4.0` published to PyPI, registered its MCP entry and completed its GitHub Release. No container image was pushed for it.

`release: published` does not reach another workflow when the release was created with `GITHUB_TOKEN` — GitHub does not raise workflow events for actions a workflow token took, which is loop prevention working as designed. And Core's tag is `core-v<version>`, which is not semver, so `type=semver` matches nothing on that ref either.

So the version is passed in rather than derived: `workflow_dispatch` takes `version` and `latest`, and the two raw tags are what a dispatch publishes. The release-event path is unchanged for a release created any other way.