### PR TITLE
docs: 1.4.0 is on PyPI, so stop saying it is not

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,6 @@ here and saying "this release" of all of them would not have been true.
 
 ### I have an agent already → Watch Skill
 
-> **On PyPI, one version behind.** `watch-skill` is published and installs
-> today; the newest release on PyPI is 1.2.0. The 1.4.0 this page describes is
-> published by the `core-v1.4.0` release.
-
 ```bash
 pip install 'watch-skill[standard]'   # frames, retrieval and the MCP server
 watch-skill doctor                    # checks, and repairs what it can

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -15,7 +15,7 @@ else, a smaller tool is a reasonable choice.
 | | Watch Skill | [claude-video](https://github.com/bradautomates/claude-video) | [mcp-video-analyzer](https://github.com/guimatheus92/mcp-video-analyzer) | [screenpipe](https://github.com/screenpipe/screenpipe) | Upload to a frontier model |
 |---|---|---|---|---|---|
 | Stars | 267 | 14,528 | 42 | 20,816 | — |
-| Last release | v1.2.0, 2026-08-08 | v0.2.0, 2026-06-29 | active | active | — |
+| Last release | v1.4.0, 2026-09-06 | v0.2.0, 2026-06-29 | active | active | — |
 | Last commit | 2026-08-09 | 2026-06-30 | 2026-08-04 | 2026-08-08 | — |
 | Open PRs | 1 | 71 | — | — | — |
 | Frames + OCR + transcript | yes | yes | yes | screen only | varies |

--- a/workspace/docs/install-and-upgrade.md
+++ b/workspace/docs/install-and-upgrade.md
@@ -3,12 +3,13 @@
 Two products, two package managers, two upgrade stories. This page covers both
 and is honest about which parts have been exercised and which have not.
 
-> **Registry status.** `watch-skill` is on PyPI; the newest published version is
-> 1.2.0, and 1.4.0 is published by the `core-v1.4.0` release. Nothing exists
-> under the `@deepwatch` scope at all — the twenty packages are published for
-> the first time by `deepwatch-v0.1.0`. Until those tags run, the registry
-> commands below are the commands you *will* run, and the from-a-checkout path
-> is the one that works today.
+> **Registry status.** `watch-skill` is on PyPI and the newest published
+> version is 1.4.0 — `pip install 'watch-skill[standard]'` gives you the
+> release this page describes. Nothing exists under the `@deepwatch` scope
+> yet: the twenty packages are published for the first time by
+> `deepwatch-v0.1.0`, so until that tag runs the npm commands below are the
+> commands you *will* run, and the from-a-checkout path is the one that works
+> today.
 
 ---
 

--- a/workspace/docs/known-limitations.md
+++ b/workspace/docs/known-limitations.md
@@ -157,12 +157,23 @@ Memory is not enabled by default. The store is plaintext and says so; it is
 created owner-only where the operating system enforces file modes. There is no
 encryption in this release, and nothing here should be read as providing it.
 
-## Nothing is published
+## DeepWatch is not published; Watch Skill is
 
-The twenty `@deepwatch/*` packages are prepared as verified tarballs and are not
-on any registry. `npx @deepwatch/cli` does not work today and there are no npm
-download figures to quote. `doctor` reports the composition it was built to
-compose and does not claim a registry can confirm it.
+Watch Skill 1.4.0 is on PyPI, in the MCP registry, and on
+`ghcr.io/oxbshw/watch-skill`. The twenty `@deepwatch/*` packages are not on any
+registry: they are prepared as verified tarballs, `npx @deepwatch/cli` does not
+work, and there are no npm download figures to quote.
+
+The reason is specific rather than a delay. `release-deepwatch.yml` publishes
+over OIDC with no token path at all, and npm requires a package to exist before
+a Trusted Publisher can be configured for it — so the *first* publication of
+each of the twenty has to be made by the release owner with a short-lived
+credential, through `scripts/first-publish.mjs`. Every publication after that
+one goes through the workflow.
+
+Until then `deepwatch setup --artifacts <dir>` is the supported path and it is
+the one both acceptance passes use. `doctor` reports the composition it was
+built to compose and says outright that no registry can confirm it.
 
 The desktop application is `private` and is not published by this release. The
 Electron shell starts and its context isolation holds — `npm run smoke:desktop`

--- a/workspace/docs/release-manifest.json
+++ b/workspace/docs/release-manifest.json
@@ -66,7 +66,7 @@
       {
         "name": "@deepwatch/dsh-bundle",
         "version": "0.1.0",
-        "integrity": "sha256:eca326d2ec31ee48316ed0c8fd05c06d08bd7d936f8e3c67ab80a22ad21b8a5a",
+        "integrity": "sha256:9cb189989815d4813eb7a6f285ac292edf9061203e6507b3a2d2c8fece1410a3",
         "sourceFiles": 7
       },
       {
@@ -189,7 +189,7 @@
       "creators": [
         "Tool: watch-gen-release-manifest"
       ],
-      "created": "2026-09-06T11:53:38Z"
+      "created": "2026-09-06T16:43:44Z"
     },
     "packages": [
       {
@@ -236,7 +236,7 @@
         "checksums": [
           {
             "algorithm": "SHA256",
-            "checksumValue": "eca326d2ec31ee48316ed0c8fd05c06d08bd7d936f8e3c67ab80a22ad21b8a5a"
+            "checksumValue": "9cb189989815d4813eb7a6f285ac292edf9061203e6507b3a2d2c8fece1410a3"
           }
         ]
       },

--- a/workspace/packages/watch/bundle/README.md
+++ b/workspace/packages/watch/bundle/README.md
@@ -29,10 +29,9 @@ For the full experience, install the engine too:
 pip install watch-skill
 ```
 
-`watch-skill` is on PyPI and installs today; the newest published version is
-1.2.0, and the 1.4.0 this bundle is built against is published by the
-`core-v1.4.0` release. The Bridge finds the executable on `PATH` and connects
-on its own.
+`watch-skill` is on PyPI and the newest published version is 1.4.0 — the
+release this bundle is built against. The Bridge finds the executable on
+`PATH` and connects on its own.
 
 ## Stability
 

--- a/workspace/tests/pending-release-claims.test.mjs
+++ b/workspace/tests/pending-release-claims.test.mjs
@@ -1,8 +1,9 @@
 /**
- * No page tells a visitor to install something that is not published.
+ * No page tells a visitor to install something that is not published, and no
+ * page tells a visitor something is unpublished once it is.
  *
  * The README's first instruction was `npm install -g @deepwatch/cli`, written
- * plainly, with an npm version badge above it. Nothing exists under the
+ * plainly, with an npm version badge above it. Nothing existed under the
  * `@deepwatch` scope — the twenty packages are published for the first time by
  * the `deepwatch-v0.1.0` tag — so the first thing a visitor did was run a
  * command that resolves nothing, on the page that was supposed to introduce
@@ -13,14 +14,27 @@
  * and `docs/releasing.md` states it as a rule: *no document in this repository
  * may say it does*. The README disagreed with both, and nothing checked.
  *
- * So this is the check. Every registry install command naming the `@deepwatch`
- * scope has to sit under a statement that it is pending a release. Not a
+ * So this is the check — and it has two halves, because a release train has
+ * two ways to lie about a registry and this file was written knowing only one
+ * of them.
+ *
+ * **Before publication**, every registry install command naming the
+ * `@deepwatch` scope has to sit under a statement that it is pending. Not a
  * disclaimer at the bottom of the page — within a dozen lines, where somebody
  * about to copy the command will read it.
  *
- * The rule is deliberately about *this* scope and *this* moment. When the
- * first publication happens, these markers come out, and the failure of this
- * test is the reminder to take them out.
+ * **After publication**, the same markers become the lie. A page still saying
+ * "not on npm yet" about a scope that is live sends a reader to a checkout
+ * build they do not need, and it is exactly the kind of sentence nobody
+ * re-reads. So the rule inverts on one switch: `deepwatch.registryStatus` in
+ * the workspace manifest, which is also what `gen-package-docs.mjs` reads.
+ *
+ * The same mistake has a second shape, and Watch Skill made it. `watch-skill`
+ * *is* published, so its honest note was never "pending" but "which version
+ * you actually get" — and the moment `core-v1.4.0` reached PyPI, three pages
+ * went on saying the newest release was 1.2.0. A currency claim about a
+ * registry is a fact with an expiry date, and the last test here is what
+ * notices when one expires.
  */
 
 import { test, describe } from 'node:test'
@@ -32,6 +46,19 @@ import { fileURLToPath } from 'node:url'
 
 const WORKSPACE = join(dirname(fileURLToPath(import.meta.url)), '..')
 const REPO = join(WORKSPACE, '..')
+
+/** The one switch. `unpublished` while the scope is empty, `published` after. */
+const REGISTRY_STATUS
+  = JSON.parse(readFileSync(join(WORKSPACE, 'package.json'), 'utf8'))
+    .deepwatch?.registryStatus ?? 'published'
+
+/** The Core version this repository declares, which is what PyPI should hold. */
+function declaredCoreVersion() {
+  const text = readFileSync(join(REPO, 'pyproject.toml'), 'utf8')
+  const match = /^version\s*=\s*"([^"]+)"/m.exec(text)
+  assert.notEqual(match, null, 'pyproject.toml declares no version')
+  return match[1]
+}
 
 /**
  * How far above a command a reader is credited with looking.
@@ -46,7 +73,7 @@ const NEARBY_LINES = 12
 const INSTALL = /(?:npm\s+(?:install|i|exec)|npx|pnpm\s+(?:add|dlx)|yarn\s+(?:add|dlx)|bun\s+(?:add|x)|dsh\s+plugin\b[^\n]*\badd)\b[^\n]*@deepwatch\//
 
 /**
- * The claim that makes such a command honest today.
+ * The claim that makes such a command honest before publication.
  *
  * Phrased loosely on purpose. The first version of this list enumerated the
  * exact sentences the README used, and then failed on
@@ -55,7 +82,7 @@ const INSTALL = /(?:npm\s+(?:install|i|exec)|npx|pnpm\s+(?:add|dlx)|yarn\s+(?:ad
  * had not been told about. A guard against dishonest documentation should not
  * also be a style guide for how to be honest.
  */
-const PENDING = /not on npm yet|not published yet|are not published|pending[^\n]{0,40}release|first publication|has never published|never published/i
+const PENDING = /not on npm yet|not published yet|are not published|pending[^\n]{0,40}release|first publication|has never published|never published|does not exist yet|nothing exists under/i
 
 /** Documentation, as the release-surface gate defines it, minus its history. */
 function documents() {
@@ -74,20 +101,28 @@ function documents() {
     .filter(line => !line.endsWith('tests/pending-release-claims.test.mjs'))
 }
 
-describe('an unpublished package is never presented as installable', () => {
+/** A line that is itself saying the command does not work. */
+function disclaims(line) {
+  if (PENDING.test(line)) return true
+  return /\b(?:do not|does not|cannot|must not|there is no|never)\b/i.test(line)
+}
+
+describe('an unpublished package is never presented as installable', {
+  skip: REGISTRY_STATUS === 'published'
+    ? 'the @deepwatch scope is published; the inverse rule applies'
+    : false,
+}, () => {
   test('every @deepwatch install command is marked pending, near enough to read', () => {
     const offenders = []
     for (const relative of documents()) {
       const lines = readFileSync(join(REPO, relative), 'utf8').split(/\r?\n/)
       lines.forEach((line, index) => {
         if (!INSTALL.test(line)) return
-        // A line that is itself saying the command does not work. These read
-        // naturally in several shapes -- "there is no `npx @deepwatch/cli`",
-        // "`npx @deepwatch/cli` does not work today" -- and a rule that only
-        // recognised one of them would flag the very sentences it exists to
-        // require.
-        if (PENDING.test(line)) return
-        if (/\b(?:do not|does not|cannot|must not|there is no|never)\b/i.test(line)) return
+        // These read naturally in several shapes -- "there is no
+        // `npx @deepwatch/cli`", "`npx @deepwatch/cli` does not work today" --
+        // and a rule that only recognised one of them would flag the very
+        // sentences it exists to require.
+        if (disclaims(line)) return
         const context = lines.slice(Math.max(0, index - NEARBY_LINES), index + 1).join('\n')
         if (PENDING.test(context)) return
         offenders.push(`${relative}:${String(index + 1)}: ${line.trim()}`)
@@ -97,14 +132,10 @@ describe('an unpublished package is never presented as installable', () => {
       'these tell a visitor to install a package that does not exist yet')
   })
 
-  test('the README says it in both halves, because it has two entry paths', () => {
+  test('the README says it where the npm entry path is', () => {
     const readme = readFileSync(join(REPO, 'README.md'), 'utf8')
     assert.match(readme, /\*\*Not on npm yet\.\*\*/)
     assert.match(readme, /deepwatch-v0\.1\.0/)
-    // And the other train, which is the opposite mistake: `watch-skill` *is*
-    // published, so the honest note is which version a visitor actually gets.
-    assert.match(readme, /\*\*On PyPI, one version behind\.\*\*/)
-    assert.match(readme, /core-v1\.4\.0/)
   })
 
   test('the working path today is named, not just the pending one', () => {
@@ -122,5 +153,82 @@ describe('an unpublished package is never presented as installable', () => {
     assert.match(releasing, /no document in this repository may\s*\n?\s*say it does/)
     const started = readFileSync(join(WORKSPACE, 'docs', 'getting-started.md'), 'utf8')
     assert.match(started, /packages are not published yet/)
+  })
+})
+
+describe('a published package is never presented as pending', {
+  skip: REGISTRY_STATUS === 'unpublished'
+    ? 'the @deepwatch scope is still empty; the pending rule applies'
+    : false,
+}, () => {
+  test('no page still says the @deepwatch scope holds nothing', () => {
+    const offenders = []
+    for (const relative of documents()) {
+      const lines = readFileSync(join(REPO, relative), 'utf8').split(/\r?\n/)
+      lines.forEach((line, index) => {
+        if (!/@deepwatch|DeepWatch/.test(line)) return
+        if (!PENDING.test(line)) return
+        offenders.push(`${relative}:${String(index + 1)}: ${line.trim()}`)
+      })
+    }
+    assert.deepEqual(offenders, [],
+      'the scope is published; these still tell a reader it is not')
+  })
+
+  test('the README shows the install command with no pending caveat over it', () => {
+    const readme = readFileSync(join(REPO, 'README.md'), 'utf8')
+    assert.match(readme, /npm install -g @deepwatch\/cli/)
+    assert.doesNotMatch(readme, /\*\*Not on npm yet\.\*\*/)
+  })
+})
+
+describe('a currency claim about a registry has an expiry date', () => {
+  /**
+   * Sentences that say what a registry holds *now*.
+   *
+   * Not every version number in a document is a claim about the present. A
+   * changelog entry, a compatibility range and an upgrade example all name
+   * old versions legitimately. What expires is the shape "the newest
+   * published version is X" -- so that shape is what is matched, and a line
+   * that marks itself as a past observation ("on 2026-09-05 it was") is left
+   * alone.
+   */
+  const CURRENCY = /\b(?:newest|latest|current)\b[^.\n]{0,60}\b(?:publish|release|on PyPI)/i
+  const HISTORICAL = /\bon 20\d\d-\d\d-\d\d\b|\bat the time\b|\bused to\b|\bwas\b/i
+  const SEMVER = /\b(\d+)\.(\d+)\.(\d+)(rc|a|b|\.dev)?\d*\b/g
+
+  function older(version, than) {
+    const left = version.split('.').map(Number)
+    const right = than.split('.').map(Number)
+    for (let at = 0; at < 3; at += 1) {
+      if (left[at] !== right[at]) return left[at] < right[at]
+    }
+    return false
+  }
+
+  test('no page says PyPI holds a Watch Skill older than the one declared here', () => {
+    const declared = declaredCoreVersion()
+    const offenders = []
+    for (const relative of documents()) {
+      const text = readFileSync(join(REPO, relative), 'utf8')
+      // Sentences, not lines: these claims wrap, and half of one reads as
+      // neither a currency claim nor a version.
+      for (const sentence of text.split(/(?<=[.!?])\s+/)) {
+        if (!CURRENCY.test(sentence)) continue
+        if (HISTORICAL.test(sentence)) continue
+        if (!/watch-skill|PyPI/i.test(sentence)) continue
+        for (const match of sentence.matchAll(SEMVER)) {
+          // A prerelease is never the answer to "what does `pip install` give
+          // you", so naming one is not a currency claim about the stable line.
+          if (match[4] !== undefined) continue
+          const found = `${match[1]}.${match[2]}.${match[3]}`
+          if (older(found, declared)) {
+            offenders.push(`${relative}: names ${found} where ${declared} is published`)
+          }
+        }
+      }
+    }
+    assert.deepEqual(offenders, [],
+      `PyPI holds watch-skill ${declared}; these pages still name an older release as current`)
   })
 })


### PR DESCRIPTION
`core-v1.4.0` published: PyPI 1.4.0, the MCP registry entry, a non-prerelease GitHub Release with its sealed assets, and `ghcr.io/oxbshw/watch-skill:1.4.0` and `:latest`.

The README's "one version behind" notice is removed. The npm notice stays, because it is still true, and known-limitations now says *why* rather than implying a delay: npm requires a package to exist before a Trusted Publisher can be configured for it, so the first publication of each of the twenty has to be made by the release owner with a short-lived credential.