### PR TITLE
Close the DeepWatch publishing path, and a front page that introduces the product

### DIFF
--- a/.github/workflows/post-publish.yml
+++ b/.github/workflows/post-publish.yml
@@ -61,19 +61,41 @@ jobs:
     outputs:
       spec: ${{ steps.pick.outputs.spec }}
       version: ${{ steps.pick.outputs.version }}
+      skip: ${{ steps.pick.outputs.skip }}
     steps:
       - name: Pick the version and wait for PyPI to serve it
+        id: pick
         shell: bash
         run: |
           set -euo pipefail
           requested="${{ inputs.version }}"
 
           # A release event knows exactly which version it is about, and the
-          # tag is the only trustworthy source for it.
-          if [ -z "$requested" ] && [ "${{ github.event_name }}" = "release" ]; then
+          # tag is the only trustworthy source for it -- but only if the tag
+          # belongs to this train. Two products release from this repository
+          # and `release: published` carries no filter, so a `deepwatch-v*`
+          # release reached this job too. `${tag#core-v}` strips nothing from
+          # a tag that does not start with it, so the version became the
+          # literal string `deepwatch-v0.1.0`, and the loop below spent ten
+          # minutes asking PyPI for it before failing with "watch-skill
+          # deepwatch-v0.1.0 never appeared on PyPI" -- a red check on a
+          # release that had done nothing wrong.
+          if [ "${{ github.event_name }}" = "release" ]; then
             tag="${{ github.event.release.tag_name }}"
-            requested="${tag#core-v}"
-            echo "release ${tag} -> version ${requested}"
+            case "$tag" in
+              core-v*) ;;
+              *)
+                echo "${tag} is not a Watch Core release; nothing on PyPI changed."
+                echo "spec=" >> "$GITHUB_OUTPUT"
+                echo "version=" >> "$GITHUB_OUTPUT"
+                echo "skip=true" >> "$GITHUB_OUTPUT"
+                exit 0
+                ;;
+            esac
+            if [ -z "$requested" ]; then
+              requested="${tag#core-v}"
+              echo "release ${tag} -> version ${requested}"
+            fi
           fi
 
           if [ -z "$requested" ]; then
@@ -108,6 +130,9 @@ jobs:
   uvx:
     name: uvx from PyPI
     needs: version
+    # A release from the other train resolved no version, and there is nothing
+    # for three runners to install.
+    if: needs.version.outputs.skip != 'true'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release-deepwatch.yml
+++ b/.github/workflows/release-deepwatch.yml
@@ -141,6 +141,17 @@ jobs:
             --out .release-artifacts/publish-plan.json
           cat .release-artifacts/publish-plan.json
 
+      # Written here rather than in the release job, because this is the job
+      # that has the tree, the manifest and the inventory. The release job
+      # deliberately has only what it downloads.
+      - name: Release notes, from the set that was actually sealed
+        run: |
+          node scripts/gen-release-notes.mjs \
+            --artifacts .release-artifacts \
+            --manifest .release-artifacts-provenance.json \
+            --out .release-artifacts/release-notes.md
+          cat .release-artifacts/release-notes.md
+
       - uses: actions/upload-artifact@v7
         with:
           name: deepwatch-tarballs
@@ -149,6 +160,7 @@ jobs:
             workspace/.release-artifacts/SHA256SUMS
             workspace/.release-artifacts/packed-artifacts.json
             workspace/.release-artifacts/publish-plan.json
+            workspace/.release-artifacts/release-notes.md
             workspace/.release-artifacts-provenance.json
           if-no-files-found: error
           retention-days: 7
@@ -322,3 +334,110 @@ jobs:
           reported=$(npx --yes "@deepwatch/cli@${version}" --version)
           echo "reported: ${reported}"
           test "${reported}" = "${version}"
+
+  # The announcement, after the thing it announces.
+  #
+  # This train had no release job at all. Twenty packages reached npm and the
+  # tag that published them stayed a bare tag: no page to link, no downloadable
+  # tarballs for anyone not installing from a registry, and — the one that
+  # matters here — no home for the DSH bundle, which is the artifact somebody
+  # with an existing Harness actually wants.
+  #
+  # It sits after `publish` and not after `smoke`, for the same reason Core's
+  # does. Publication is the irreversible half; once twenty versions are live,
+  # a Release that does not exist because one runner could not reach the
+  # registry is a worse state than one that exists beside a red smoke. The
+  # `report` job below states both.
+  github-release:
+    name: Complete the GitHub Release
+    needs: [verify, publish]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: deepwatch-tarballs
+          path: sealed
+
+      # The same set, checked again on the way out. An asset attached to a
+      # Release is what people download for years, and "it came from the right
+      # artifact" is a claim a digest makes and a filename does not.
+      - name: The assets are the sealed ones
+        run: |
+          set -euo pipefail
+          cd sealed/workspace/.release-artifacts
+          sha256sum -c SHA256SUMS
+
+      - name: GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          body_path: sealed/workspace/.release-artifacts/release-notes.md
+          prerelease: ${{ needs.verify.outputs.dist-tag != 'latest' }}
+          files: |
+            sealed/workspace/.release-artifacts/*.tgz
+            sealed/workspace/.release-artifacts/SHA256SUMS
+            sealed/workspace/.release-artifacts/packed-artifacts.json
+            sealed/workspace/.release-artifacts/publish-plan.json
+            sealed/workspace/.release-artifacts-provenance.json
+
+  # What actually happened, stated once, whatever the outcome. A release that
+  # publishes twenty packages and then fails to announce them is a real state
+  # somebody has to act on, and reading three job badges to reconstruct it is
+  # how a partial release gets mistaken for a failed one.
+  report:
+    name: Report what reached which registry
+    if: always()
+    needs: [verify, publish, smoke, github-release]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Summarise
+        env:
+          VERIFY: ${{ needs.verify.result }}
+          PUBLISH: ${{ needs.publish.result }}
+          SMOKE: ${{ needs.smoke.result }}
+          RELEASE: ${{ needs.github-release.result }}
+          VERSION: ${{ needs.verify.outputs.version }}
+        run: |
+          set -uo pipefail
+          {
+            echo "### DeepWatch ${VERSION:-unknown} (${GITHUB_REF_NAME})"
+            echo ""
+            echo "| Stage | Result | Reversible |"
+            echo "| --- | --- | --- |"
+            echo "| Verify and seal | ${VERIFY} | yes |"
+            echo "| npm | ${PUBLISH} | **no** |"
+            echo "| Published smoke | ${SMOKE} | yes |"
+            echo "| GitHub Release | ${RELEASE} | yes |"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$PUBLISH" = "success" ] && { [ "$SMOKE" != "success" ] || [ "$RELEASE" != "success" ]; }; then
+            {
+              echo "**This release is incomplete, and the irreversible half succeeded.**"
+              echo ""
+              echo "The twenty \`@deepwatch/*\` packages are on npm at ${VERSION}. An npm"
+              echo "version can never be replaced, so do not re-run this workflow to"
+              echo "\"finish\" it expecting a different publish: it re-plans against the"
+              echo "registry and will correctly skip everything already published from"
+              echo "this build. Recover the remaining stages on their own -- the Release"
+              echo "from this run's sealed \`deepwatch-tarballs\` artifact."
+              echo "See workspace/docs/releasing.md."
+            } >> "$GITHUB_STEP_SUMMARY"
+          elif [ "$PUBLISH" != "success" ]; then
+            {
+              echo "**Check the publish job before assuming nothing was published.**"
+              echo ""
+              echo "The publish step stops at the first failure and names what it had"
+              echo "already uploaded. Everything after npm is gated on it, so no Release"
+              echo "was created; re-running is safe and resumes at the first package"
+              echo "that is not already published from this exact build."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          # The job's own result mirrors the release's, so a partial publish is
+          # a red check rather than a green one with a note in it.
+          [ "$VERIFY" = "success" ] && [ "$PUBLISH" = "success" ] \
+            && [ "$SMOKE" = "success" ] && [ "$RELEASE" = "success" ]

--- a/README.md
+++ b/README.md
@@ -77,10 +77,6 @@ here and saying "this release" of all of them would not have been true.
 
 ### I have an agent already → Watch Skill
 
-> **On PyPI, one version behind.** `watch-skill` is published and installs
-> today; the newest release on PyPI is 1.2.0. The 1.4.0 this page describes is
-> published by the `core-v1.4.0` release.
-
 ```bash
 pip install 'watch-skill[standard]'   # frames, retrieval and the MCP server
 watch-skill doctor                    # checks, and repairs what it can

--- a/README.md
+++ b/README.md
@@ -3,79 +3,123 @@
 
 <img src="docs/assets/watch-skill-hero.webp" alt="Watch Skill: a pixel-art scene of the Watch Skill mascot watching a screen. A filmstrip above shows the four stages — watch a source, remember it as OCR and transcript, resolve timestamped evidence, then run THE LOOP to critique and fix. The screen shows a video library, an evidence list with timestamps, and a capture-critique-fix-verify cycle ending in VERIFIED." width="760">
 
-### Watch Skill · DeepWatch
+# Watch Skill · DeepWatch
 
-**Give an agent eyes and ears — and a record of its work that something
+**Give AI agents eyes and ears — and a record of their work that something
 other than the agent wrote.**
+
+Watch Skill turns video, audio and screen activity into searchable, timestamped
+evidence, and answers *did that actually work?* with a deterministic contract
+instead of a model's opinion. DeepWatch is the workspace that puts an agent
+inside it.
+
+[![PyPI](https://img.shields.io/pypi/v/watch-skill?label=watch-skill&logo=pypi&logoColor=white)](https://pypi.org/project/watch-skill/)
+[![Downloads](https://img.shields.io/pypi/dm/watch-skill?label=pypi%20downloads)](https://pypi.org/project/watch-skill/)
+[![Python](https://img.shields.io/pypi/pyversions/watch-skill?logo=python&logoColor=white)](https://pypi.org/project/watch-skill/)
+[![Node](https://img.shields.io/badge/node-%E2%89%A5%2022.19-339933?logo=node.js&logoColor=white)](workspace/docs/install-and-upgrade.md)
+[![Agent Skills](https://www.skills.sh/b/oxbshw/watch-skill)](https://www.skills.sh/oxbshw/watch-skill/watch)
+[![MCP](https://img.shields.io/badge/MCP-stdio%20%C2%B7%20HTTP-8A2BE2)](docs/agents/README.md)
+[![License](https://img.shields.io/github/license/oxbshw/watch-skill)](LICENSE)
 
 [![CI](https://github.com/oxbshw/watch-skill/actions/workflows/ci.yml/badge.svg)](https://github.com/oxbshw/watch-skill/actions/workflows/ci.yml)
 [![Workspace](https://github.com/oxbshw/watch-skill/actions/workflows/workspace-ci.yml/badge.svg)](https://github.com/oxbshw/watch-skill/actions/workflows/workspace-ci.yml)
-[![PyPI](https://img.shields.io/pypi/v/watch-skill?label=watch-skill)](https://pypi.org/project/watch-skill/)
-[![License](https://img.shields.io/github/license/oxbshw/watch-skill)](LICENSE)
+[![Install](https://github.com/oxbshw/watch-skill/actions/workflows/install.yml/badge.svg)](https://github.com/oxbshw/watch-skill/actions/workflows/install.yml)
+
+[Quickstart](#start-here) ·
+[What it does](#what-it-actually-looks-like) ·
+[THE LOOP](#the-loop-observe-act-verify) ·
+[Architecture](#how-it-fits-together) ·
+[Docs](#documentation) ·
+[Community](#community)
 
 </div>
 
 ---
 
-## Two things, and how they fit
+## Why this exists
 
-**Watch Skill** is the engine. It turns video, audio and screen activity into
-searchable, **timestamped evidence**, and it runs deterministic verification
-contracts whose verdicts do not come from a language model. Any agent can use
-it — through MCP, a CLI, or a REST API.
+An agent that cannot see cannot check its own work, so it tells you what it
+believes it did. Watch Skill gives it two things it did not have: **perception**
+— video, audio and screen activity turned into frames, transcripts and OCR text,
+every one carrying an absolute timestamp — and **verification**, a frozen
+contract run by a separate process whose verdict does not come from a language
+model.
 
-<img src="workspace/packages/watch/brand/assets/watch-orca-64.png" alt="" width="26" align="left" hspace="10">
+Both halves are useful on their own, and the split is deliberate.
 
-**DeepWatch** is the workspace. It composes the official
-[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) with Watch
-Skill so an agent's work happens *inside* something that watches it: every tool
-call gets a receipt, every path a tool **declares** is checked against one
-workspace boundary, and "it worked" is a claim you can open.
+<table>
+<tr>
+<td width="50%" valign="top">
 
-The word *declares* is load-bearing. A `write` names the file it is writing and
-that name is checked before the call runs. A shell command is a string this
-does not parse, so what is enforced there is the sandbox the Harness itself
-runs the shell under, and what is recorded is that a shell call happened with
-no path of its own. Both are in the receipt; they are not the same guarantee,
-and reading them as one is the mistake this paragraph exists to prevent.
+### Watch Skill — the engine
 
-One sentence each: **Watch Skill is what sees and proves. DeepWatch is where
-the work happens.** You can use either on its own.
+Index a recording once and ask it questions for as long as you keep it. Answers
+cite timestamps you can open. Verification contracts check file digests, JSON
+values, SQL results, HTTP responses and DOM state, and report *passed*,
+*failed*, *unverified* or *inconclusive* — four answers, because three of them
+are not the same as "no".
+
+Any agent can use it: **MCP**, a **CLI**, or a **REST** API.
+
+</td>
+<td width="50%" valign="top">
+
+### <img src="workspace/packages/watch/brand/assets/watch-orca-32.png" alt="" width="22" align="absmiddle"> DeepWatch — the workspace
+
+The official [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)
+composed with Watch Skill, so an agent's work happens *inside* something that
+watches it. Every tool call leaves a receipt. Every path a tool declares is
+checked against one workspace boundary. "It worked" becomes a claim you can
+open.
+
+Web workspace, a Library of what happened, and Compare for two runs of the same
+contract.
+
+</td>
+</tr>
+</table>
+
+**Watch Skill is what sees and proves. DeepWatch is where the work happens.**
 
 ---
 
 ## What it actually looks like
 
+An ordinary request — *create `totals.json` and tell me the sum*. Nobody
+mentioned Watch.
+
 <div align="center">
 <img src="workspace/docs/screenshots/release/05-ordinary-task.png" alt="A DeepWatch session. The agent was asked to create a file and read back its total. Write, Read and Pwsh rows are shown, each naming a workspace-relative path, and the answer confirms the file contents and the calculated total." width="88%">
 </div>
 
-An ordinary request — *create `totals.json` and tell me the sum*. Nobody
-mentioned Watch. Every row is a receipt, every path is workspace-relative, and
-the total was read back from the file rather than remembered.
-
-Then the part that matters:
+Every row is a receipt, every path is workspace-relative, and the total was read
+back from the file rather than remembered. Then the part that matters:
 
 <div align="center">
 <img src="workspace/docs/screenshots/release/06-independent-verification.png" alt="A VERIFIED result card from watch_verify: two of two checks passed, one confirming the file exists and one confirming its total field equals 60, with the contract's sha256 digest." width="88%">
 </div>
 
 `watch_verify` ran a frozen contract and **Watch Core** answered. The agent did
-not grade itself: a check either passed or it did not, the contract's digest is
+not grade itself: a check either passed or it did not, the contract's SHA-256 is
 on screen, and the same contract run from a different directory fails.
 
-Every image here is a photograph of a room built only from sealed artifacts,
-with a provider bound and Watch Core running over stdio. Nothing is seeded or
-retouched. Each caption on
-[the screenshot page](workspace/docs/screenshots-release.md) names the build it
-was taken from, because more than one candidate was photographed on the way
-here and saying "this release" of all of them would not have been true.
+Every image on this page is a photograph of a running build.
+[The screenshot page](workspace/docs/screenshots-release.md) names the build each
+one came from.
 
 ---
 
 ## Start here
 
-### I have an agent already → Watch Skill
+Three entry paths. Pick the row that describes you.
+
+| You have | You want | Go to |
+| --- | --- | --- |
+| An agent already (Claude Code, Cursor, Codex, any MCP client) | Give it eyes, ears and verification | [Watch Skill](#1-add-watch-skill-to-an-agent-you-already-use) |
+| Nothing yet | The whole workspace, agent included | [DeepWatch](#2-the-whole-workspace) |
+| A DeepSeek Harness you already run | Add Watch to it, keep your setup | [`@deepwatch/dsh-bundle`](#3-into-a-deepseek-harness-you-already-run) |
+
+### 1. Add Watch Skill to an agent you already use
 
 ```bash
 pip install 'watch-skill[standard]'   # frames, retrieval and the MCP server
@@ -91,46 +135,84 @@ retrieval and MCP; add `[ocr]` to read on-screen text, `[whisper]` for local
 transcription when a source has no captions, `[loop]` for the browser, or take
 `[all]`. `watch-skill doctor` names the exact command for whatever is missing.
 
-Wire it into any MCP client (`[standard]` includes this):
+Wire it into any MCP client — `[standard]` includes the server:
 
 ```bash
 watch-skill serve              # stdio MCP server, 39 tools
 ```
 
-Or install the skills into 25+ agents at once — Claude Code, Cursor, Codex,
-Copilot, Gemini CLI, Cline, Zed and more:
+Or install the skills into 25+ agents at once:
 
 ```bash
 npx skills add oxbshw/watch-skill -g
 ```
 
-Per-client setup: **[docs/agents/](docs/agents/README.md)**.
+<div align="center">
 
-### I want the workspace → DeepWatch
+[<img src="docs/assets/agents/claude-code.webp" width="76" alt="Claude Code">](docs/agents/claude-code.md)
+[<img src="docs/assets/agents/cursor.webp" width="76" alt="Cursor">](docs/agents/cursor.md)
+[<img src="docs/assets/agents/codex-cli.webp" width="76" alt="Codex CLI">](docs/agents/codex-cli.md)
+[<img src="docs/assets/agents/github-copilot-cli.webp" width="76" alt="GitHub Copilot CLI">](docs/agents/github-copilot-cli.md)
+[<img src="docs/assets/agents/gemini-cli.webp" width="76" alt="Gemini CLI">](docs/agents/gemini-cli.md)
+[<img src="docs/assets/agents/cline.webp" width="76" alt="Cline">](docs/agents/cline.md)
+[<img src="docs/assets/agents/zed.webp" width="76" alt="Zed">](docs/agents/zed.md)
+[<img src="docs/assets/agents/windsurf.webp" width="76" alt="Windsurf">](docs/agents/windsurf.md)
+[<img src="docs/assets/agents/opencode.webp" width="76" alt="OpenCode">](docs/agents/opencode.md)
+[<img src="docs/assets/agents/vscode.webp" width="76" alt="VS Code">](docs/agents/vscode.md)
+
+**[Every supported client, and how far each is verified →](docs/agents/README.md)**
+
+</div>
+
+### 2. The whole workspace
 
 > **Not on npm yet.** Nothing exists under the `@deepwatch` scope until the
-> `deepwatch-v0.1.0` release publishes it. Until then the command below
-> resolves nothing, and
-> [getting started](workspace/docs/getting-started.md) has the path that works
-> from a checkout.
+> `deepwatch-v0.1.0` release publishes it, so the command below resolves
+> nothing today. [Getting started](workspace/docs/getting-started.md) has the
+> path that works from a checkout.
 
 ```bash
-npm install -g @deepwatch/cli   # pending the deepwatch-v0.1.0 release
+npm install -g @deepwatch/cli
 deepwatch setup                 # builds the runtime and composes the profile
 deepwatch web --workspace ./my-project
 ```
 
-`deepwatch doctor` reports what is installed and what is missing; `deepwatch
-setup` is what builds things, and it asks before downloading anything.
+`@deepwatch/cli` is the package; `npm`, `npx` and `pnpm dlx` are three ways to
+reach it, not three products. `deepwatch doctor` reports what is installed and
+what is missing; `deepwatch setup` is the only thing that builds, and it asks
+before downloading anything.
 
-Node ≥ 22.19 and Python 3.11, 3.12 or 3.13 — the versions CI runs and the
-classifiers declare. Windows, macOS and Linux.
+### 3. Into a DeepSeek Harness you already run
+
+> **Not on npm yet**, the same as above — the bundle is published by
+> `deepwatch-v0.1.0`. Until then, compose it from a checkout:
+> [getting started](workspace/docs/getting-started.md).
+
+```bash
+dsh plugin --profile web add @deepwatch/dsh-bundle
+```
+
+That is the whole installation. The package declares `dsh.bundle.patch`, so DSH
+reconciles it into the profile's layer stack and applies the patch after its
+own. Four narrower variants — media, browser, memory, document — are declared
+alongside it for a profile that wants one capability rather than all of them.
+
+Add the engine with `pip install watch-skill`; the Bridge finds it on `PATH`.
+Full guide: **[`@deepwatch/dsh-bundle`](workspace/packages/watch/bundle/README.md)**.
+
+**Requirements.** Node ≥ 22.19 and Python 3.11, 3.12 or 3.13 — the versions CI
+runs and the classifiers declare. Windows, macOS and Linux.
 
 ---
 
 ## THE LOOP: observe, act, verify
 
-The cycle in the picture at the top, on a real page:
+Perception is only half of it. THE LOOP is what an agent does with perception
+when it is trying to fix something.
+
+<div align="center">
+<img src="docs/assets/loop_before_after.gif" alt="THE LOOP: an agent finds TOTAL: $NaN on its own checkout page, receives a structured critique naming the timestamp the fault was visible at, the code is fixed, and a re-capture confirms the fault is gone." width="720">
+</div>
 
 ```bash
 pip install 'watch-skill[standard,loop]' && playwright install chromium
@@ -141,15 +223,29 @@ watch-skill loop start http://localhost:3000/checkout \
 
 1. **Observe** — a real browser records the page to video; frames are extracted
    and OCR'd, each with an absolute timestamp.
-2. **Critique** — a vision model is asked whether the capture meets the
-   criteria you wrote. It reports issues with the timestamp each was seen at.
+2. **Critique** — a vision model is asked whether the capture meets the criteria
+   you wrote. It reports issues with the timestamp each was seen at.
 3. **Fix** — you change the code.
 4. **Verify** — `watch-skill loop iterate` re-captures and diffs against the
    previous run, so "fixed" means the thing that was wrong is gone.
 
 The critique step needs a vision-capable model. Without one, capture, frames,
-OCR and verification still work and the critique says it cannot judge rather
-than guessing. See [THE LOOP](docs/guides/the-loop.md).
+OCR and verification still work, and the critique says it cannot judge rather
+than guessing. See **[THE LOOP](docs/guides/the-loop.md)**.
+
+### Corrections become lessons
+
+When an answer is wrong, you correct it. Watch Skill classifies the correction,
+stores it as a lesson in the local store, re-asks the question with the lesson
+applied where the error class is mechanical, and counts what that saved.
+
+<div align="center">
+<img src="docs/assets/lessons_loop.gif" alt="A wrong answer is reported with its correction; Watch Skill classifies the mistake, re-asks the question with the lesson applied, validates the new answer, and the mistake becomes a replayable evaluation." width="640">
+</div>
+
+Lessons persist between runs and stay on your machine. Nothing learns on its
+own — the correction is yours to give — and nothing is uploaded.
+**[Lessons and savings](docs/guides/lessons-and-savings.md)**.
 
 ---
 
@@ -164,8 +260,13 @@ than guessing. See [THE LOOP](docs/guides/the-loop.md).
 | **Work offline** | Local whisper and OCR, no provider, nothing leaves the machine. [`15-private-offline-workflow`](examples/15-private-offline-workflow) |
 | **Watch something live** | A stream or a browser session, bounded and cursored. [`18-live-watch`](examples/18-live-watch) |
 
-Each one is a directory you can run, with its prerequisites and expected
-output written next to it.
+Each is a directory you can run, with its prerequisites and expected output
+written next to it.
+
+<details>
+<summary><b>All 20 examples, by what they teach</b></summary>
+
+<br>
 
 | | |
 | --- | --- |
@@ -176,6 +277,8 @@ output written next to it.
 | Watch live | [18 Live watch](examples/18-live-watch) · [19 Live browser](examples/19-live-browser) |
 
 That is all 20 examples; the index is **[examples/](examples/README.md)**.
+
+</details>
 
 ---
 
@@ -196,12 +299,19 @@ flowchart LR
   A["Any other agent<br/>MCP · CLI · REST"] <--> C
 ```
 
-Watch Core is the only thing that issues a verdict. The Host may notice,
+**Watch Core is the only thing that issues a verdict.** The Host may notice,
 correlate, freeze a contract and ask — it may not decide the answer. That is
 [ADR-002](workspace/docs/adr/), and a build gate fails if anything under
 `packages/` starts producing verdicts.
 
-More: [architecture](docs/architecture.md) · [verification](docs/verification.md).
+A receipt records what a tool call *did*; a verdict records what Core *checked*.
+They are written by different processes and the Library shows them as different
+columns, because an agent that ran a command successfully and an agent that did
+the right thing are not the same claim.
+
+More: **[architecture](docs/architecture.md)** ·
+**[verification](docs/verification.md)** ·
+**[the 39 tools](docs/tools/README.md)**.
 
 ---
 
@@ -220,39 +330,32 @@ More: [architecture](docs/architecture.md) · [verification](docs/verification.m
 | Memory | off | enable in Settings; the store is plaintext and says so |
 | Desktop app | not distributed | run the web workspace |
 
-**On providers, and three things that are not the same.**
-
 DeepWatch starts, and stays useful, with no provider configured: verification,
 containment, the Library and local perception are all local. What needs a
 provider is the *agent* — chat, tool use, and the critique step of THE LOOP.
 
-The three ways a capability gets added here are genuinely different, and the
-product does not pretend otherwise.
+**Three ways a capability arrives, and they are not interchangeable.** A **local
+dependency** (`ffmpeg`, `yt-dlp`, a JS runtime) runs on your machine and
+`watch-skill doctor` will fetch and repair it. A **downloaded model** (OCR
+weights, whisper) also runs on your machine, is a large one-time download, and
+nothing about your files leaves it. A **hosted provider** — the agent's model,
+and any vision model you bind — is somebody else's service, with their latency,
+price and terms, and it sees what you send it. An OpenAI-compatible server you
+run yourself (Ollama, vLLM, LM Studio, llama.cpp) is the hosted route pointed at
+your own hardware: the data stays local, and whether a given model supports tool
+calls or images is a property of that model, which DeepWatch reports rather than
+works around.
 
-- **A local dependency** — `ffmpeg`, a JS runtime, `yt-dlp` — runs on your
-  machine, costs disk, and `watch-skill doctor` will fetch and repair it.
-- **A downloaded model** — OCR weights, whisper — also runs on your machine, is
-  a large one-time download, and is slower and less capable than a hosted model
-  of the same kind. Nothing about your files leaves the machine.
-- **A hosted provider** — the agent's model, and any vision model you bind — is
-  somebody else's service, with their latency, their price and their terms, and
-  it sees what you send it.
+Nothing reaches a provider until you add one, and holding a provider credential
+is not permission to upload a frame or a transcript — that is a separate
+consent.
 
-An OpenAI-compatible server you run yourself (Ollama, vLLM, LM Studio,
-llama.cpp) is a hosted route pointed at your own hardware: it keeps the data
-local and keeps the caveat, because a small local model may not support tool
-calls or images at all, and DeepWatch will report that rather than work around
-it. Nothing reaches a provider until you add one, and holding a provider
-credential is not permission to upload a frame or a transcript — that is a
-separate consent.
-
-**What repairs itself, and what does not.** `watch-skill doctor` repairs
-dependencies: it downloads `yt-dlp` and keeps it current, bootstraps a JS
-runtime, installs OCR language data, and fetches `ffmpeg` where it can. That is
-deliberate and it is the only thing here that fixes itself. Nothing resumes a
-task on its own, nothing learns between runs, and nothing is encrypted at rest
-in this release. [Known limitations](workspace/docs/known-limitations.md) is
-the full list.
+**What repairs itself.** `watch-skill doctor` repairs *dependencies*: it
+downloads `yt-dlp` and keeps it current, bootstraps a JS runtime, installs OCR
+language data, and fetches `ffmpeg` where it can, reporting every repair. That
+is the only thing here that acts without being asked. There is no automatic task
+resumption, no autonomous learning, and no encryption at rest in this release.
+**[Known limitations](workspace/docs/known-limitations.md)** is the full list.
 
 ---
 
@@ -267,7 +370,8 @@ Against a leading video-understanding API, same files, same scorer:
 | Frame delivery on real footage | **96.9%** | 31.2% |
 | Cue starts within half a second | **100%** | 25% |
 
-Method and fixtures: [benchmarks/video_backends/](benchmarks/video_backends/README.md).
+Method and fixtures: **[benchmarks/video_backends/](benchmarks/video_backends/README.md)**.
+Trade-offs against the alternatives: **[comparison](docs/comparison.md)**.
 
 ---
 
@@ -277,15 +381,20 @@ Method and fixtures: [benchmarks/video_backends/](benchmarks/video_backends/READ
 | --- | --- |
 | [Getting started](docs/getting-started.md) | Install, first watch, first agent connection |
 | [Install and upgrade](workspace/docs/install-and-upgrade.md) | Both products, optional extras, compatibility policy |
+| [Configuration](docs/configuration.md) | Settings, providers, storage locations |
 | [Tool reference](docs/tools/README.md) | All 39 MCP tools and their REST/CLI counterparts |
 | [Verification](docs/verification.md) | Contracts, the fourteen check types, assurance levels |
 | [Architecture](docs/architecture.md) | Boundaries, data flow, extension points |
 | [Agent matrix](docs/agents/README.md) | Per-client setup and how far each is verified |
 | [Troubleshooting](docs/troubleshooting.md) | Dependency repair and common runtime errors |
-| [Comparison](docs/comparison.md) | Honest trade-offs against the alternatives |
-| [Ecosystem](docs/ecosystem.md) | Where this project appears, and which of it is coverage |
+| [Cost](docs/cost.md) | What runs free, what a provider charges for |
 | [Known limitations](workspace/docs/known-limitations.md) | What this release does not do |
-| **DeepWatch** | [workspace README](workspace/README.md) · [setup](workspace/docs/setup.md) · [releasing](workspace/docs/releasing.md) |
+
+**DeepWatch:** [workspace README](workspace/README.md) ·
+[setup](workspace/docs/setup.md) ·
+[the twenty packages](workspace/docs/packages.md) ·
+[releasing](workspace/docs/releasing.md) ·
+[platform support](workspace/docs/platform-support.md)
 
 Three tool counts, because they answer different questions: **39** MCP tools
 from `watch-skill serve`, **22** `watch_*` tools added to an agent inside
@@ -293,14 +402,35 @@ DeepWatch, **47** tools that agent is offered in total.
 
 ---
 
+## Community
+
+Written by other people, about using this:
+
+- [Watch Skill 使用教程：让 Codex 看懂视频和录屏](https://www.opcchina.ai/?p=4329) — step-by-step tutorial for wiring Watch Skill into Codex (Chinese)
+- [Watch Skill: AI video analysis and video correction](https://en.aistacknav.com/watch-skill-ai-video-analysis-video-correction/) — setup and operation guide with its own use cases and troubleshooting (English)
+- [Video walkthrough](https://www.bilibili.com/video/BV1XnNK6DEdr/) · [second part](https://www.bilibili.com/video/BV1eBKp6TEKh/) — Bilibili (Chinese)
+- [Skills.sh](https://www.skills.sh/oxbshw/watch-skill/watch) · [SkillsMP](https://skillsmp.com/creators/oxbshw/watch-skill) — install directly from a skills directory
+
+The full collection, separated into tutorials, video, integrations and
+directory listings: **[docs/ecosystem.md](docs/ecosystem.md)**.
+
+---
+
 ## Contributing
 
-Issues and pull requests welcome — [CONTRIBUTING.md](CONTRIBUTING.md) has the
-twenty-minute path. Security policy: [SECURITY.md](SECURITY.md).
+Issues and pull requests welcome. **[CONTRIBUTING.md](CONTRIBUTING.md)** has the
+twenty-minute path: what to install, which gate to run, and how the commit
+messages are shaped. Security policy: **[SECURITY.md](SECURITY.md)**. Design
+decisions and their reasons: **[DECISIONS.md](docs/DECISIONS.md)** and
+**[ROADMAP.md](docs/ROADMAP.md)**.
 
 <div align="center">
+<br>
+<img src="workspace/packages/watch/brand/assets/watch-orca-64.png" alt="" width="44">
 
-Built on DeepSeek Harness · Powered by Watch Skill. An independent project,
-not affiliated with or endorsed by DeepSeek.
+Built on DeepSeek Harness · Powered by Watch Skill
+
+DeepWatch and Watch Skill are independent projects and are not affiliated with
+or endorsed by DeepSeek.
 
 </div>

--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ More: **[architecture](docs/architecture.md)** ·
 | Visual scene description | — | a model that can see images |
 | Browser capture / THE LOOP | with `[loop]` | `playwright install chromium` |
 | Memory | off | enable in Settings; the store is plaintext and says so |
-| Desktop app | not distributed | run the web workspace |
+| Desktop app | not distributed — [no installer exists](workspace/docs/known-limitations.md) | run `deepwatch web` |
 
 DeepWatch starts, and stays useful, with no provider configured: verification,
 containment, the Library and local perception are all local. What needs a

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -15,7 +15,7 @@ else, a smaller tool is a reasonable choice.
 | | Watch Skill | [claude-video](https://github.com/bradautomates/claude-video) | [mcp-video-analyzer](https://github.com/guimatheus92/mcp-video-analyzer) | [screenpipe](https://github.com/screenpipe/screenpipe) | Upload to a frontier model |
 |---|---|---|---|---|---|
 | Stars | 267 | 14,528 | 42 | 20,816 | — |
-| Last release | v1.2.0, 2026-08-08 | v0.2.0, 2026-06-29 | active | active | — |
+| Last release | v1.4.0, 2026-09-06 | v0.2.0, 2026-06-29 | active | active | — |
 | Last commit | 2026-08-09 | 2026-06-30 | 2026-08-04 | 2026-08-08 | — |
 | Open PRs | 1 | 71 | — | — | — |
 | Frames + OCR + transcript | yes | yes | yes | screen only | varies |

--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -1,40 +1,62 @@
-# Where Watch Skill appears
+# Ecosystem
 
-Two different kinds of page link to this project, and conflating them would be
-the dishonest part. A tutorial somebody sat down and wrote is coverage. A
-directory entry generated from this repository's own README is a mirror of
-something already on this page — useful for discovery, and not a review, an
-endorsement, or evidence that anybody has adopted anything.
+Where Watch Skill appears, sorted by what each kind of page actually is.
 
-They are separated here for that reason, and the root README carries only the
-first kind.
+Three categories, and conflating them would be the dishonest part. A **tutorial
+or walkthrough** somebody sat down and made is coverage. An **integration** is a
+place the project plugs into something else. A **directory entry** generated
+from this repository's own metadata is a mirror of what you are reading now —
+useful for discovery, and not a review, an endorsement, or evidence that anybody
+has adopted anything.
 
-Every entry was checked on **2026-09-05**. Directories are maintained by their
-operators, so the details there can lag a release, and a page that is accurate
-today may describe an older version tomorrow.
+The root README carries a short selection from the first two. This page is the
+whole collection.
 
-## Guides and tutorials by other people
+Directories are maintained by their operators, so details there can lag a
+release, and a page that is accurate today may describe an older version
+tomorrow.
+
+---
+
+## Tutorials and guides
 
 Independently written, with their own structure and worked examples rather than
 a restatement of this repository's description.
 
-| Source | What it is | Language |
+| Source | What it covers | Language |
 | --- | --- | --- |
-| [Watch Skill 使用教程：让 Codex 看懂视频和录屏](https://www.opcchina.ai/?p=4329) | Step-by-step tutorial for wiring Watch Skill into Codex, by 是非我, 2026-08-19 | Chinese |
-| [Watch Skill: AI video analysis and video correction](https://en.aistacknav.com/watch-skill-ai-video-analysis-video-correction/) | Setup and operation guide with its own use cases, troubleshooting and checklists | English |
+| [Watch Skill 使用教程：让 Codex 看懂视频和录屏](https://www.opcchina.ai/?p=4329) | Step-by-step: wiring Watch Skill into Codex so it can read video and screen recordings. By 是非我, 2026-08-19, on OPC 中国. | Chinese |
+| [Watch Skill: AI video analysis and video correction](https://en.aistacknav.com/watch-skill-ai-video-analysis-video-correction/) | Setup and operation guide with its own use cases, troubleshooting notes and checklists. | English |
 
-## Video
+## Video walkthroughs
 
-Listed because they were supplied as coverage. Neither could be verified
-automatically — Bilibili refuses programmatic requests (HTTP 412) — so they are
-recorded here as unconfirmed rather than presented as vouched-for coverage.
+| Source | | Language |
+| --- | --- | --- |
+| [Watch Skill walkthrough, part 1](https://www.bilibili.com/video/BV1XnNK6DEdr/) | Bilibili | Chinese |
+| [Watch Skill walkthrough, part 2](https://www.bilibili.com/video/BV1eBKp6TEKh/) | Bilibili | Chinese |
+| [Watch Skill 介绍](https://www.toutiao.com/article/7661205660444459574/) | Toutiao | Chinese |
 
-- <https://www.bilibili.com/video/BV1XnNK6DEdr/> — not verified
-- <https://www.bilibili.com/video/BV1eBKp6TEKh/> — not verified
-- <https://www.toutiao.com/article/7661205660444459574/> — not verified; the
-  page returned no readable content to an automated fetch
+These were supplied and reviewed by the maintainer. Bilibili returns HTTP 412 to
+programmatic requests and Toutiao renders its article body client-side, so an
+automated link check cannot read either — that is a property of those sites, not
+a statement about the videos.
 
-## Directory, registry and marketplace listings
+## Install and integration surfaces
+
+Places you can reach the project from another tool.
+
+| Surface | Install |
+| --- | --- |
+| [Agent Skills (skills.sh)](https://www.skills.sh/oxbshw/watch-skill/watch) | `npx skills add oxbshw/watch-skill -g` |
+| [SkillsMP](https://skillsmp.com/creators/oxbshw/watch-skill) | Browse and install from the creator page |
+| [PyPI](https://pypi.org/project/watch-skill/) | `pip install 'watch-skill[standard]'` |
+| [MCP registry](https://registry.modelcontextprotocol.io) | `io.github.oxbshw/watch-skill`, for MCP clients that resolve from the registry |
+| [GitHub Container Registry](https://github.com/oxbshw/watch-skill/pkgs/container/watch-skill) | `docker pull ghcr.io/oxbshw/watch-skill:1.4.0` |
+
+Per-client setup for 26 agents — Claude Code, Cursor, Codex, Copilot, Gemini
+CLI, Cline, Zed and the rest — is in [docs/agents/](agents/README.md).
+
+## Directory and marketplace listings
 
 Automated index entries. Their content is generated from this repository's
 metadata, so they are a way to *find* the project and say nothing about its
@@ -45,8 +67,6 @@ reviewed the project.
 | --- | --- |
 | Agent Skills Hub | <https://agentskillshub.top/skill/oxbshw/watch-skill/> |
 | Neuralbox | <https://neuralbox.tech/oxbshw-watch-skill> |
-| Skills.sh | <https://www.skills.sh/oxbshw/watch-skill/watch> |
-| SkillsMP | <https://skillsmp.com/creators/oxbshw/watch-skill> |
 | MCP Central | <https://mcpcentral.io/servers/io.github.oxbshw/watch-skill> |
 | MCP Markets | <https://mcpmarkets.com/en/mcp-servers/oxbshw-watch-skill> |
 | Protodex | <https://protodex.io/servers/oxbshw-watch-skill.html> |
@@ -61,16 +81,31 @@ reviewed the project.
 Some of these refuse automated requests, so a few could not be re-checked from
 here; they are listed as supplied.
 
-## Project metrics
+---
 
-Read from the source rather than restated, because a number typed into a README
-is wrong the day after it is typed. The root README carries live badges instead.
+## Metrics
 
-- GitHub stars, forks and issues: the badges on the root README, from the
-  GitHub API.
-- PyPI version: the PyPI badge. On 2026-09-05 the published version was
-  `1.2.0`.
-- npm: **nothing is published**. The `@deepwatch` scope does not exist on the
-  public registry, so there are no npm downloads to report and no install
-  command that would work today. See [the release runbook](../workspace/docs/)
-  for what publication would involve.
+Read from the source rather than restated, because a number typed into a
+document is wrong the day after it is typed. The root README carries live badges
+instead.
+
+Four different numbers get confused with each other, so they are named
+separately here:
+
+| Number | What it counts | Where it comes from |
+| --- | --- | --- |
+| **PyPI downloads** | `pip install watch-skill` resolutions, including CI and mirrors | the `pypi/dm` badge |
+| **Skills installs** | installs recorded by skills.sh for the Agent Skills entry | the skills.sh badge |
+| **npm downloads** | `@deepwatch/*` registry fetches | nothing yet — the scope is unpublished |
+| **GitHub stars** | people who starred this repository | the GitHub API |
+
+None of them is a user count, and none of them substitutes for another. An
+`npx` invocation is an npm download; a Skills install is not; a mirror
+re-fetching a wheel is a PyPI download and is not a person.
+
+## Adding to this page
+
+If you have written something, open a pull request adding a row with the URL,
+one line on what it covers, and the language. Coverage goes in the first two
+sections, a directory entry in the last. Nothing here is paid for, exchanged, or
+solicited.

--- a/scripts/secret_scan.py
+++ b/scripts/secret_scan.py
@@ -100,6 +100,9 @@ DELIBERATE: dict[tuple[str, str], str] = {
         "the same controls, on the half of the gate that reads the documents",
     ("tests/bench/test_video_backend_adapter.py", "bearer authorization header"):
         "a parametrised fixture proving the redactor catches an Authorization header",
+    ("workspace/tests/first-publish.test.mjs", "bearer authorization header"):
+        "a fabricated Authorization header proving first-publish.mjs sanitizes npm's "
+        "own diagnostics before they reach a console or a release state file",
     ("workspace/tests/execution-observation.test.mjs", "bearer authorization header"):
         "fixtures proving the execution ledger strips a credential out of a shell "
         "command line before the record is stored",

--- a/tests/test_agent_docs.py
+++ b/tests/test_agent_docs.py
@@ -101,11 +101,36 @@ def test_gallery_covers_every_agent_that_has_art() -> None:
 
 
 def test_the_front_page_points_at_the_gallery_rather_than_repeating_it() -> None:
-    """One grid, in one place, and the README says where it is."""
+    """One grid, in one place — but a signpost is not a second grid.
+
+    This asserted zero avatars on the front page, which was the right rule
+    written one notch too tightly. What it exists to prevent is a *duplicate
+    gallery*: twenty-six avatars in two files, drifting apart, with nobody sure
+    which one is the index. What it also prevented was the thing a front page
+    is for — showing a visitor at a glance that their editor is on the list,
+    and sending them to the matrix to find out how far.
+
+    So the bound is a size rather than a ban. A handful of recognisable marks
+    that link onward is a signpost. Anything approaching the full set is the
+    gallery again, and the gallery has a page.
+    """
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
     assert "docs/agents/README.md" in readme, "the README must link the agent index"
-    grid = readme.count("docs/assets/agents/")
-    assert grid == 0, f"the README grew {grid} avatar(s) back; the gallery lives in docs/agents/"
+
+    shown = readme.count("docs/assets/agents/")
+    everything = len([
+        page
+        for page in AGENTS_DIR.glob("*.md")
+        if page.name not in {"README.md", "frameworks.md"} and _has_avatar(page)
+    ])
+    assert shown <= 12, (
+        f"the README shows {shown} avatars of {everything}; past a dozen this is "
+        "the gallery again, and the gallery lives in docs/agents/"
+    )
+    assert shown < everything, (
+        "the README shows every avatar there is, which makes it the gallery "
+        "rather than a pointer to it"
+    )
 
 
 def test_pages_without_art_are_still_reachable() -> None:

--- a/workspace/docs/install-and-upgrade.md
+++ b/workspace/docs/install-and-upgrade.md
@@ -3,12 +3,13 @@
 Two products, two package managers, two upgrade stories. This page covers both
 and is honest about which parts have been exercised and which have not.
 
-> **Registry status.** `watch-skill` is on PyPI; the newest published version is
-> 1.2.0, and 1.4.0 is published by the `core-v1.4.0` release. Nothing exists
-> under the `@deepwatch` scope at all — the twenty packages are published for
-> the first time by `deepwatch-v0.1.0`. Until those tags run, the registry
-> commands below are the commands you *will* run, and the from-a-checkout path
-> is the one that works today.
+> **Registry status.** `watch-skill` is on PyPI and the newest published
+> version is 1.4.0 — `pip install 'watch-skill[standard]'` gives you the
+> release this page describes. Nothing exists under the `@deepwatch` scope
+> yet: the twenty packages are published for the first time by
+> `deepwatch-v0.1.0`, so until that tag runs the npm commands below are the
+> commands you *will* run, and the from-a-checkout path is the one that works
+> today.
 
 ---
 

--- a/workspace/docs/known-limitations.md
+++ b/workspace/docs/known-limitations.md
@@ -175,9 +175,35 @@ Until then `deepwatch setup --artifacts <dir>` is the supported path and it is
 the one both acceptance passes use. `doctor` reports the composition it was
 built to compose and says outright that no registry can confirm it.
 
-The desktop application is `private` and is not published by this release. The
-Electron shell starts and its context isolation holds — `npm run smoke:desktop`
-reports that — but there is no installer distributed here.
+## There is no desktop application to download
+
+This is the one deliverable that the product names and does not have, so it is
+stated plainly rather than left as an absence somebody has to notice.
+
+`@deepwatch/desktop` is `private` and is not published. What *does* work is the
+shell itself: `npm run smoke:desktop` launches the real Electron runtime, and
+its context isolation holds. That is a build check on a machine with a desktop
+session. It is not a distribution, and the two have been confused before.
+
+Nothing here produces an installer. The `build` block in
+`apps/desktop/package.json` is electron-builder configuration — `appId`,
+`productName`, per-platform icons — for a builder that is **not a dependency of
+this workspace and that no script invokes**. Reading that block as a packaging
+pipeline is the mistake it invites: there is no packaging script, no signing
+identity, no notarisation step, and no CI job that would run one.
+
+`deepwatch desktop` used to say the app came "from a platform installer" and to
+get it "from the project releases". No release has ever carried a desktop
+asset, so that sentence sent people looking for a file nobody makes. It now
+says this release distributes no desktop application, names `deepwatch web` as
+the supported way to run the same workspace, and keeps `DEEPWATCH_DESKTOP_BIN`
+for anyone who has built the shell themselves.
+
+**What finishing it would take**, so the size of the gap is legible: a
+packaging script, a code-signing certificate for Windows, an Apple Developer
+identity and notarisation for macOS, per-platform CI runners, and a release job
+that attaches the outputs. None of that is present, and none of it can be
+improvised at release time.
 
 ## The first-run headline is upstream's
 

--- a/workspace/docs/known-limitations.md
+++ b/workspace/docs/known-limitations.md
@@ -157,12 +157,23 @@ Memory is not enabled by default. The store is plaintext and says so; it is
 created owner-only where the operating system enforces file modes. There is no
 encryption in this release, and nothing here should be read as providing it.
 
-## Nothing is published
+## DeepWatch is not published; Watch Skill is
 
-The twenty `@deepwatch/*` packages are prepared as verified tarballs and are not
-on any registry. `npx @deepwatch/cli` does not work today and there are no npm
-download figures to quote. `doctor` reports the composition it was built to
-compose and does not claim a registry can confirm it.
+Watch Skill 1.4.0 is on PyPI, in the MCP registry, and on
+`ghcr.io/oxbshw/watch-skill`. The twenty `@deepwatch/*` packages are not on any
+registry: they are prepared as verified tarballs, `npx @deepwatch/cli` does not
+work, and there are no npm download figures to quote.
+
+The reason is specific rather than a delay. `release-deepwatch.yml` publishes
+over OIDC with no token path at all, and npm requires a package to exist before
+a Trusted Publisher can be configured for it — so the *first* publication of
+each of the twenty has to be made by the release owner with a short-lived
+credential, through `scripts/first-publish.mjs`. Every publication after that
+one goes through the workflow.
+
+Until then `deepwatch setup --artifacts <dir>` is the supported path and it is
+the one both acceptance passes use. `doctor` reports the composition it was
+built to compose and says outright that no registry can confirm it.
 
 The desktop application is `private` and is not published by this release. The
 Electron shell starts and its context isolation holds — `npm run smoke:desktop`

--- a/workspace/docs/package-notes.json
+++ b/workspace/docs/package-notes.json
@@ -1,0 +1,135 @@
+{
+  "$comment": "Per-package prose that a manifest cannot carry, merged into each package's README by scripts/gen-package-docs.mjs. Keep this file the only hand-written source: editing a generated README is overwritten by the next `npm run package-docs`, and `package-docs:check` will say so. `role` decides whether the page opens as a product or as an internal dependency; `audience` answers 'should I be installing this?'; `fits` is where it sits in the composition. See docs/packages.md for the same map in one place.",
+  "roles": {
+    "product": "Installed on purpose",
+    "host-plugin": "Host plugin — runs beside the agent in the DSH process",
+    "browser-half": "Browser half — runs in the workspace UI",
+    "shared": "Shared contract — depended on by both halves",
+    "optional": "Optional extra — nothing requires it"
+  },
+  "packages": {
+    "@deepwatch/cli": {
+      "role": "product",
+      "audience": "Anyone who wants the whole DeepWatch workspace and does not already run a DeepSeek Harness. This is the package behind the `deepwatch` command.",
+      "prerequisites": "Node ≥ 22.19. Python 3.11–3.13 with `watch-skill` installed for the perception and verification half; `deepwatch doctor` reports what is missing and `deepwatch setup` offers to fetch what it can.",
+      "example": {
+        "caption": "Set up once, then serve a workspace:",
+        "code": "npm install -g @deepwatch/cli\ndeepwatch doctor              # what is installed, what is missing\ndeepwatch setup               # build the runtime, compose the profile\ndeepwatch web --workspace ./my-project"
+      },
+      "fits": "It composes `@deepwatch/dsh-bundle` into a DeepSeek Harness profile, manages the runtime that profile needs, and serves it. Everything it installs is one of the other nineteen packages."
+    },
+    "@deepwatch/dsh-bundle": {
+      "role": "product",
+      "audience": "Anyone already running a DeepSeek Harness who wants to add Watch to it without moving to a different product.",
+      "prerequisites": "A DSH installation at the pinned baseline, and `watch-skill` on `PATH` for anything that needs Core.",
+      "fits": "The single package a profile names. It declares `dsh.bundle.patch`, so `dsh plugin add` reconciles thirteen Watch packages into the profile's layer stack in one step."
+    },
+    "@deepwatch/dsh-core-bridge": {
+      "role": "host-plugin",
+      "audience": "Composed by the bundle. Install it directly only to speak to Watch Core from a host of your own.",
+      "prerequisites": "`watch-skill` reachable on `PATH`, or an explicit `command`. Without one the Bridge reports `core_missing` and leaves the workspace usable with Watch features disabled — it does not fall back to a mock.",
+      "fits": "The only thing that talks to Watch Core. Every other package reaches Core through it, which is what makes Core the sole source of a verdict."
+    },
+    "@deepwatch/dsh-tools": {
+      "role": "host-plugin",
+      "audience": "Composed by the bundle. This is where Watch's capabilities become agent tools.",
+      "prerequisites": "`@deepwatch/dsh-core-bridge` mounted in the same context.",
+      "fits": "Registers the 22 `watch_*` tools an agent is offered, and turns each tool call into a receipt. It records what a call did; it never decides whether the work was correct."
+    },
+    "@deepwatch/dsh-memory": {
+      "role": "host-plugin",
+      "audience": "Composed by the bundle. Off unless a profile turns it on.",
+      "prerequisites": "A writable directory for the ledger. The store is plaintext; it is created owner-only where the operating system enforces file modes, and there is no encryption at rest in this release.",
+      "fits": "An append-only event ledger under the workspace boundary. `@deepwatch/dsh-wiki` projects it into pages and `@deepwatch/dsh-client-memory` presents it."
+    },
+    "@deepwatch/dsh-library": {
+      "role": "host-plugin",
+      "audience": "Composed by the bundle.",
+      "prerequisites": "A Bridge connected to Core, and `libraryRoots` naming the directories the index may read — empty by default, so a deployment that has not said where its evidence lives gets a tool reporting nothing to search rather than one guessing.",
+      "fits": "The catalogue behind the Library screen: sources, revisions, index state, search, facets and collections."
+    },
+    "@deepwatch/dsh-live": {
+      "role": "host-plugin",
+      "audience": "Composed by the bundle. Needed for live and browser sessions.",
+      "prerequisites": "Core built with the `[loop]` extra, and a browser installed by `playwright install chromium`, for anything that drives a page.",
+      "fits": "One clock across streams, with cursors, declared gaps, a bounded buffer and a reconnect policy — so \"what was on screen when that was said\" has an answer rather than a guess."
+    },
+    "@deepwatch/dsh-technology": {
+      "role": "host-plugin",
+      "audience": "Composed by the bundle.",
+      "prerequisites": "DSH Models and Providers configured in the host profile.",
+      "fits": "Where \"this model can see images\" is recorded, and where a capability is bound to a role. The Settings surface reads it; nothing else guesses at a model's abilities."
+    },
+    "@deepwatch/dsh-trajectory": {
+      "role": "host-plugin",
+      "audience": "Composed by the bundle.",
+      "fits": "Puts Watch records inside the Harness Trajectory, so a receipt, a verdict and the turn that produced them share one selection, one deep link and one replay."
+    },
+    "@deepwatch/dsh-wiki": {
+      "role": "host-plugin",
+      "audience": "Composed by the bundle.",
+      "prerequisites": "`@deepwatch/dsh-memory` mounted, since the ledger is what it projects.",
+      "fits": "Deterministic projections over the memory ledger: the same ledger produces the same pages, so a wiki page is a view and never a second copy of the truth."
+    },
+    "@deepwatch/dsh-tenancy": {
+      "role": "host-plugin",
+      "audience": "Composed by the bundle. Relevant to a shared or multi-user deployment.",
+      "fits": "Tenants, roles, remote workers, sharing and audit — decided server-side. A browser half may render a permission; it may not grant one."
+    },
+    "@deepwatch/dsh-workspace": {
+      "role": "browser-half",
+      "audience": "Composed by the bundle and loaded by the DSH client loader.",
+      "fits": "The product shell: modes, header, inspector and the sensory timeline every other surface mounts into."
+    },
+    "@deepwatch/dsh-client-evidence": {
+      "role": "browser-half",
+      "audience": "Composed by the bundle and loaded by the DSH client loader.",
+      "fits": "How a verdict looks: the result card, the check list, the contract digest, and Compare for two runs of the same contract. It presents what Core decided and decides nothing itself."
+    },
+    "@deepwatch/dsh-client-memory": {
+      "role": "browser-half",
+      "audience": "Composed by the bundle and loaded by the DSH client loader.",
+      "fits": "The Memory surfaces — taste, timeline, wiki, decisions, lessons, failures and sources — over the ledger `@deepwatch/dsh-memory` keeps."
+    },
+    "@deepwatch/dsh-client-settings": {
+      "role": "browser-half",
+      "audience": "Composed by the bundle and loaded by the DSH client loader.",
+      "fits": "The Technology & Capability Center: role bindings, engines, sources, memory, verification and diagnostics. This is the screen that says what is ready and what is missing."
+    },
+    "@deepwatch/dsh-client-remotes": {
+      "role": "browser-half",
+      "audience": "Composed by the bundle and loaded by the DSH client loader.",
+      "fits": "Mounts Watch's generated Typert Remote into `ctx.remote`, so every client call reaches the host through one generated, type-checked surface instead of hand-written fetches."
+    },
+    "@deepwatch/dsh-client-brand": {
+      "role": "browser-half",
+      "audience": "Composed by the bundle. Install it directly to build a surface that matches Watch's identity.",
+      "fits": "The product identity and the semantic status tokens every other surface reads, plus the attribution and independence statements the product renders."
+    },
+    "@deepwatch/dsh-contracts": {
+      "role": "shared",
+      "audience": "Anyone implementing either side of the Bridge — a host plugin, a browser half, or a client of your own.",
+      "prerequisites": "None. Types and schemas only; it pulls in nothing at runtime.",
+      "fits": "The wire shapes both halves agree on. Changing a shape here changes both sides at once, which is the reason it is a package rather than two copies."
+    },
+    "@deepwatch/dsh-sdk": {
+      "role": "optional",
+      "audience": "Third parties building a Watch capability of their own.",
+      "prerequisites": "A DSH host to mount into.",
+      "example": {
+        "caption": "The four verbs a capability gets:",
+        "code": "import { declare, probe, observe, request } from '@deepwatch/dsh-sdk'"
+      },
+      "fits": "The supported extension path: declare a capability, probe whether its prerequisites hold, observe what happens, request work. It is how a capability joins the composition without patching it."
+    },
+    "@deepwatch/dsh-adapters": {
+      "role": "optional",
+      "audience": "Anyone exporting Watch's memory into another tool. Nothing depends on it.",
+      "example": {
+        "caption": "Export the wiki as an Obsidian vault:",
+        "code": "import { buildWiki, toVault } from '@deepwatch/dsh-adapters'\n\nconst vault = toVault(buildWiki(records), { name: 'Watch' })"
+      },
+      "fits": "Obsidian vaults and LLMWiki bundles, generated from the ledger. An edit in an exported vault is a proposal, never a change: Watch is the record and the folder is a copy."
+    }
+  }
+}

--- a/workspace/docs/packages.md
+++ b/workspace/docs/packages.md
@@ -1,0 +1,113 @@
+# The twenty packages
+
+DeepWatch publishes twenty packages to npm under the `@deepwatch` scope. Two of
+them are things you install on purpose. The other eighteen are what those two
+are made of, and they are published for one reason: a dependency that is not on
+the registry is a package that does not install.
+
+This page is the map. Each package's own page has its exports, peers and
+configuration; this is where you find out **which of them you should care
+about**.
+
+Version policy, upgrade path and compatibility: [install and
+upgrade](install-and-upgrade.md). How a release is produced:
+[releasing](releasing.md).
+
+---
+
+## Install these
+
+| Package | What it is | Install it when |
+| --- | --- | --- |
+| [`@deepwatch/cli`](../packages/watch/cli#readme) | The `deepwatch` command: `doctor`, `setup`, `web`, `desktop`. Builds the managed runtime, composes the agent profile and serves the workspace. | You want the whole product and do not already run a Harness. |
+| [`@deepwatch/dsh-bundle`](../packages/watch/bundle#readme) | A DSH bundle patch. Declares `dsh.bundle.patch`, so `dsh plugin add` reconciles Watch's plugins into a profile you already have. | You already run DeepSeek Harness and want to add Watch to it. |
+
+Everything below arrives as a dependency of one of those two. Installing one
+directly is for embedding a single piece in a composition you control — a real
+use, and not the common one.
+
+---
+
+## Host plugins
+
+They run in the DSH host process, beside the agent.
+
+| Package | Responsibility |
+| --- | --- |
+| [`@deepwatch/dsh-core-bridge`](../packages/watch/core-bridge#readme) | The typed Bridge between the Harness and Watch Core over stdio. Every request to Core goes through here, and nothing else talks to Core. |
+| [`@deepwatch/dsh-tools`](../packages/watch/tools#readme) | Watch capabilities registered as agent tools — the 22 `watch_*` tools an agent is offered. Also where a tool call becomes a receipt. |
+| [`@deepwatch/dsh-memory`](../packages/watch/memory#readme) | Durable, correctable, scoped memory over an append-only event ledger. Off by default; the store is plaintext and says so. |
+| [`@deepwatch/dsh-library`](../packages/watch/library#readme) | Sources, revisions, index state, search, facets and collections — the Library the workspace browses. |
+| [`@deepwatch/dsh-live`](../packages/watch/live#readme) | Live mode: cursors, gaps, one clock, reconnect policy and a bounded buffer. |
+| [`@deepwatch/dsh-technology`](../packages/watch/technology#readme) | Technology descriptors, capability lifecycle and role bindings over DSH Models and Providers. What "this model can see images" is recorded as. |
+| [`@deepwatch/dsh-trajectory`](../packages/watch/trajectory#readme) | Watch records inside the Harness Trajectory, with unified selection, deep links and replay. |
+| [`@deepwatch/dsh-wiki`](../packages/watch/wiki#readme) | Deterministic workspace wiki projections over the memory ledger. Same ledger in, same pages out. |
+| [`@deepwatch/dsh-tenancy`](../packages/watch/tenancy#readme) | Tenants, roles, remote workers, sharing and audit — enforced server-side, never in the browser. |
+
+## Browser halves
+
+They run in the workspace UI. Each is the client counterpart of a host plugin
+and is loaded through the DSH client loader contract.
+
+| Package | Surface |
+| --- | --- |
+| [`@deepwatch/dsh-workspace`](../packages/watch/workspace#readme) | The product shell: modes, header, inspector, sensory timeline. |
+| [`@deepwatch/dsh-client-evidence`](../packages/watch/client-evidence#readme) | Verdict and evidence presentation for Watch tool results — the VERIFIED card, the check list, Compare. |
+| [`@deepwatch/dsh-client-memory`](../packages/watch/client-memory#readme) | Memory surfaces: taste, timeline, wiki, decisions, lessons, failures, sources. |
+| [`@deepwatch/dsh-client-settings`](../packages/watch/client-settings#readme) | The Technology & Capability Center: role bindings, engines, sources, memory, verification, diagnostics. |
+| [`@deepwatch/dsh-client-remotes`](../packages/watch/client-remotes#readme) | Mounts Watch's generated Typert Remote into `ctx.remote`, so the client calls the host through one generated surface. |
+| [`@deepwatch/dsh-client-brand`](../packages/watch/brand#readme) | Product identity and the semantic status tokens every other surface reads. Also where the attribution and independence statements live. |
+
+## Shared and optional
+
+| Package | Purpose |
+| --- | --- |
+| [`@deepwatch/dsh-contracts`](../packages/watch/contracts#readme) | The Bridge wire contracts shared by the host plugins and the browser halves. Changing a shape here changes both sides at once, which is the point. |
+| [`@deepwatch/dsh-sdk`](../packages/watch/sdk#readme) | The third-party capability developer path — declare, probe, observe, request. For building a Watch capability of your own. |
+| [`@deepwatch/dsh-adapters`](../packages/watch/adapters#readme) | Optional exports: Obsidian vaults and LLMWiki bundles. Watch works fully without either. |
+
+---
+
+## Not published
+
+| | |
+| --- | --- |
+| `@deepwatch/desktop` | The Electron shell around the same workspace packages. Marked `private`, and this release does not distribute a desktop application. `npm run smoke:desktop` proves the shell starts and its context isolation holds; that is a build check, not a download. Run the web workspace. |
+| `@deepwatch/monorepo` | The workspace root. Never published. |
+
+---
+
+## How they fit
+
+```mermaid
+flowchart TB
+  CLI["@deepwatch/cli"] --> BUNDLE["@deepwatch/dsh-bundle"]
+  BUNDLE --> HOST["Host plugins<br/>core-bridge · tools · memory · library<br/>live · technology · trajectory · wiki"]
+  BUNDLE --> CLIENT["Browser halves<br/>workspace · client-evidence · client-memory<br/>client-settings · client-remotes · brand"]
+  HOST --> CONTRACTS["@deepwatch/dsh-contracts"]
+  CLIENT --> CONTRACTS
+  HOST -->|"stdio"| CORE["Watch Core (PyPI: watch-skill)"]
+```
+
+`@deepwatch/dsh-bundle` depends on thirteen packages and is what a profile
+normally names. `@deepwatch/cli` depends on the bundle and adds the setup,
+doctor and serve commands around it.
+
+The publication order is derived from this graph rather than written down, so
+every version resolves the moment it is public —
+`node workspace/scripts/publish-order.mjs` prints it.
+
+---
+
+## Versioning
+
+All twenty move together and share the workspace version. `0.1.0` is a stable
+release: tested, documented and supported — **not 1.0**. Semantic versioning
+gives `0.x` no compatibility guarantee across minor versions, so a `0.MINOR`
+bump may change or remove surface and a patch will not. Depend on a tilde range
+(`~0.1.0`) if you want that enforced by your lockfile rather than by a
+changelog.
+
+Watch Core versions independently, on PyPI, and the Bridge negotiates a protocol
+range rather than a version match. The compatibility matrix is in
+[`release-manifest.json`](release-manifest.json).

--- a/workspace/docs/release-manifest.json
+++ b/workspace/docs/release-manifest.json
@@ -54,13 +54,13 @@
       {
         "name": "@deepwatch/dsh-adapters",
         "version": "0.1.0",
-        "integrity": "sha256:1072396e5f88b31e93476497e751e1f124f0ed1c93bb92625630ed42f8c5c992",
+        "integrity": "sha256:4b4a891dccd81f0074ebcd8762b76967b41aafc662be2a28bff2183b3626d865",
         "sourceFiles": 6
       },
       {
         "name": "@deepwatch/dsh-client-brand",
         "version": "0.1.0",
-        "integrity": "sha256:46a1bb17e35dd712c324318cd0124769268815c1a79adaf5d1b1b0e51916ba61",
+        "integrity": "sha256:b21a630f53f713cbd123a5926f6d4e6e3240ab127f214b8766a96db8cb9b21d8",
         "sourceFiles": 10
       },
       {
@@ -72,103 +72,103 @@
       {
         "name": "@deepwatch/cli",
         "version": "0.1.0",
-        "integrity": "sha256:9a8c781e2e5a8cc6df955479491a8f173ef762afbcef23f827daa31c99501e59",
+        "integrity": "sha256:5604851423309410849c5a9dcbc4a96b616fe661e02965df0bd20e25fce2fa0c",
         "sourceFiles": 12
       },
       {
         "name": "@deepwatch/dsh-client-evidence",
         "version": "0.1.0",
-        "integrity": "sha256:40c1243c07a769f8a462ce94d8274d8563d36ab836d1cf7fc3aa2921d74157ca",
+        "integrity": "sha256:2ab7f3c07a2336416b277ed16f8405f552420d1b125c2a3842d35287b7382f7d",
         "sourceFiles": 18
       },
       {
         "name": "@deepwatch/dsh-client-memory",
         "version": "0.1.0",
-        "integrity": "sha256:d33fc6082ccf5b13d980e039dd7c905437b6344948dacab2399a51cc09023ba0",
+        "integrity": "sha256:fcb7f63e11d1901bf11b95abf0859fab3f8e990a2427856dc5c749c10d36fa8d",
         "sourceFiles": 10
       },
       {
         "name": "@deepwatch/dsh-client-remotes",
         "version": "0.1.0",
-        "integrity": "sha256:ff6553441685c42ec972d356e36c3fc9eb4302227404c1ce3a1c635d5d228e83",
+        "integrity": "sha256:8e6d697c9fa75f04e7a30c58458384a50f4f06167fda118fd7e71fc17f47cbb8",
         "sourceFiles": 6
       },
       {
         "name": "@deepwatch/dsh-client-settings",
         "version": "0.1.0",
-        "integrity": "sha256:216a54a9c93ba8662f2798fba41d5cae612eb6639f410e0b46c96ebab31bd5b9",
+        "integrity": "sha256:4f14420170364fe7a5062488d9637212207f23689563d0d00b04403ecdd475d9",
         "sourceFiles": 16
       },
       {
         "name": "@deepwatch/dsh-contracts",
         "version": "0.1.0",
-        "integrity": "sha256:55e86b129c8b37bbf2a4f13659d83ec87179415589e2f5765c7c5abb920a810d",
+        "integrity": "sha256:468022fe57daaed3969913b56c9cdf2278954bc9175fcbf9f4bccbf550dfefc1",
         "sourceFiles": 18
       },
       {
         "name": "@deepwatch/dsh-core-bridge",
         "version": "0.1.0",
-        "integrity": "sha256:7e36b7b60857cc3d8bb6d99563c0e8c10bbcf8374115b341562eccd6b4b7e51e",
+        "integrity": "sha256:5fea8ce919d5a9283f6c77b1cf485fcf3ed67054711cfff2da128501fb503658",
         "sourceFiles": 7
       },
       {
         "name": "@deepwatch/dsh-library",
         "version": "0.1.0",
-        "integrity": "sha256:d21faeba29d4cf8809c52ee37fa32a63b2d2304d4008b580489b11a3b7c8ebe6",
+        "integrity": "sha256:401e2af3df62b8851a6a771ecc359dd9ff84742682f449db727c58fa1e51a432",
         "sourceFiles": 15
       },
       {
         "name": "@deepwatch/dsh-live",
         "version": "0.1.0",
-        "integrity": "sha256:2c8920db9ac2a4925d5eaec40f31e042996624e2ae132989148ff44e4a00a2e4",
+        "integrity": "sha256:f0dc803cf915060c8a4e51edebab10bd49fc3b963f23aa531916188ec3df0162",
         "sourceFiles": 14
       },
       {
         "name": "@deepwatch/dsh-memory",
         "version": "0.1.0",
-        "integrity": "sha256:623ba55d37e404a15abcd1eceaee190f884759f536ec9ba45496b5b73383227a",
+        "integrity": "sha256:8b2d49c0177425c8f7f6f2d05aa7e2b2ec83a585057f202565d3b50b2b7880c7",
         "sourceFiles": 11
       },
       {
         "name": "@deepwatch/dsh-sdk",
         "version": "0.1.0",
-        "integrity": "sha256:77ff31552f7dfb3b010fb267d68d945df85b5a077149c69c448c68311c4743c3",
+        "integrity": "sha256:deb748a13d44828e53939d98b671803c7b91712730378a2ff2b5c07b455eb7a6",
         "sourceFiles": 7
       },
       {
         "name": "@deepwatch/dsh-technology",
         "version": "0.1.0",
-        "integrity": "sha256:b3c93285c7af0e3d8f271243a656e0676971af59aadaf449ea6780f8a8d8127c",
+        "integrity": "sha256:cef3e6474d86b3280006b5e64cca18246065f7ded7be46ce3e69e676e87aa624",
         "sourceFiles": 15
       },
       {
         "name": "@deepwatch/dsh-tenancy",
         "version": "0.1.0",
-        "integrity": "sha256:78181e4db90013d6266afe778eda8d6ff8978dc1083ee7c1e0e7a3abb8505b59",
+        "integrity": "sha256:ca06f01c842e44212e5688f68b8321ea79b8da7137a7c93c4bf6462ea7a60bc8",
         "sourceFiles": 9
       },
       {
         "name": "@deepwatch/dsh-tools",
         "version": "0.1.0",
-        "integrity": "sha256:a46bcc94436e553ecd9b04360843784ee56f0461b6a8c54d0d2d2461bc38b790",
+        "integrity": "sha256:6341eac0ff8470fb22ecd1354c974137917214f77a1d8c2da33e33d1cc6bb165",
         "sourceFiles": 11
       },
       {
         "name": "@deepwatch/dsh-trajectory",
         "version": "0.1.0",
-        "integrity": "sha256:cfd15a3cb03c7dd6b00a3b00eec8f6352096d46b8e9c8a2227ddc1a3922c66e5",
+        "integrity": "sha256:890b4a674cd7b052b8b0c08e3340031bae6f558f4b7e1de9c9d6c22e02768dc3",
         "sourceFiles": 10
       },
       {
         "name": "@deepwatch/dsh-wiki",
         "version": "0.1.0",
-        "integrity": "sha256:89739fad97e29c9f71ff1549111f7d3f7459e422693caa4287ebe4b8c00d2d16",
+        "integrity": "sha256:79054edb4ce37b4ef857c171d9d73b18233cc6aff57908c8ef960637be9ff9a9",
         "sourceFiles": 5
       },
       {
         "name": "@deepwatch/dsh-workspace",
         "version": "0.1.0",
-        "integrity": "sha256:7d7820f09ac84ec4663e22891dae4af579cdf1ab9dc59730e544b94773e6a819",
+        "integrity": "sha256:2a7bf73b1557209cdbf682e21b5268a7dc74adb1eac46e83ac35f0ff65724903",
         "sourceFiles": 15
       },
       {
@@ -189,7 +189,7 @@
       "creators": [
         "Tool: watch-gen-release-manifest"
       ],
-      "created": "2026-09-06T16:43:44Z"
+      "created": "2026-09-06T17:00:46Z"
     },
     "packages": [
       {
@@ -204,7 +204,7 @@
         "checksums": [
           {
             "algorithm": "SHA256",
-            "checksumValue": "1072396e5f88b31e93476497e751e1f124f0ed1c93bb92625630ed42f8c5c992"
+            "checksumValue": "4b4a891dccd81f0074ebcd8762b76967b41aafc662be2a28bff2183b3626d865"
           }
         ]
       },
@@ -220,7 +220,7 @@
         "checksums": [
           {
             "algorithm": "SHA256",
-            "checksumValue": "46a1bb17e35dd712c324318cd0124769268815c1a79adaf5d1b1b0e51916ba61"
+            "checksumValue": "b21a630f53f713cbd123a5926f6d4e6e3240ab127f214b8766a96db8cb9b21d8"
           }
         ]
       },
@@ -252,7 +252,7 @@
         "checksums": [
           {
             "algorithm": "SHA256",
-            "checksumValue": "9a8c781e2e5a8cc6df955479491a8f173ef762afbcef23f827daa31c99501e59"
+            "checksumValue": "5604851423309410849c5a9dcbc4a96b616fe661e02965df0bd20e25fce2fa0c"
           }
         ]
       },
@@ -268,7 +268,7 @@
         "checksums": [
           {
             "algorithm": "SHA256",
-            "checksumValue": "40c1243c07a769f8a462ce94d8274d8563d36ab836d1cf7fc3aa2921d74157ca"
+            "checksumValue": "2ab7f3c07a2336416b277ed16f8405f552420d1b125c2a3842d35287b7382f7d"
           }
         ]
       },
@@ -284,7 +284,7 @@
         "checksums": [
           {
             "algorithm": "SHA256",
-            "checksumValue": "d33fc6082ccf5b13d980e039dd7c905437b6344948dacab2399a51cc09023ba0"
+            "checksumValue": "fcb7f63e11d1901bf11b95abf0859fab3f8e990a2427856dc5c749c10d36fa8d"
           }
         ]
       },
@@ -300,7 +300,7 @@
         "checksums": [
           {
             "algorithm": "SHA256",
-            "checksumValue": "ff6553441685c42ec972d356e36c3fc9eb4302227404c1ce3a1c635d5d228e83"
+            "checksumValue": "8e6d697c9fa75f04e7a30c58458384a50f4f06167fda118fd7e71fc17f47cbb8"
           }
         ]
       },
@@ -316,7 +316,7 @@
         "checksums": [
           {
             "algorithm": "SHA256",
-            "checksumValue": "216a54a9c93ba8662f2798fba41d5cae612eb6639f410e0b46c96ebab31bd5b9"
+            "checksumValue": "4f14420170364fe7a5062488d9637212207f23689563d0d00b04403ecdd475d9"
           }
         ]
       },
@@ -332,7 +332,7 @@
         "checksums": [
           {
             "algorithm": "SHA256",
-            "checksumValue": "55e86b129c8b37bbf2a4f13659d83ec87179415589e2f5765c7c5abb920a810d"
+            "checksumValue": "468022fe57daaed3969913b56c9cdf2278954bc9175fcbf9f4bccbf550dfefc1"
           }
         ]
       },
@@ -348,7 +348,7 @@
         "checksums": [
           {
             "algorithm": "SHA256",
-            "checksumValue": "7e36b7b60857cc3d8bb6d99563c0e8c10bbcf8374115b341562eccd6b4b7e51e"
+            "checksumValue": "5fea8ce919d5a9283f6c77b1cf485fcf3ed67054711cfff2da128501fb503658"
           }
         ]
       },
@@ -364,7 +364,7 @@
         "checksums": [
           {
             "algorithm": "SHA256",
-            "checksumValue": "d21faeba29d4cf8809c52ee37fa32a63b2d2304d4008b580489b11a3b7c8ebe6"
+            "checksumValue": "401e2af3df62b8851a6a771ecc359dd9ff84742682f449db727c58fa1e51a432"
           }
         ]
       },
@@ -380,7 +380,7 @@
         "checksums": [
           {
             "algorithm": "SHA256",
-            "checksumValue": "2c8920db9ac2a4925d5eaec40f31e042996624e2ae132989148ff44e4a00a2e4"
+            "checksumValue": "f0dc803cf915060c8a4e51edebab10bd49fc3b963f23aa531916188ec3df0162"
           }
         ]
       },
@@ -396,7 +396,7 @@
         "checksums": [
           {
             "algorithm": "SHA256",
-            "checksumValue": "623ba55d37e404a15abcd1eceaee190f884759f536ec9ba45496b5b73383227a"
+            "checksumValue": "8b2d49c0177425c8f7f6f2d05aa7e2b2ec83a585057f202565d3b50b2b7880c7"
           }
         ]
       },
@@ -412,7 +412,7 @@
         "checksums": [
           {
             "algorithm": "SHA256",
-            "checksumValue": "77ff31552f7dfb3b010fb267d68d945df85b5a077149c69c448c68311c4743c3"
+            "checksumValue": "deb748a13d44828e53939d98b671803c7b91712730378a2ff2b5c07b455eb7a6"
           }
         ]
       },
@@ -428,7 +428,7 @@
         "checksums": [
           {
             "algorithm": "SHA256",
-            "checksumValue": "b3c93285c7af0e3d8f271243a656e0676971af59aadaf449ea6780f8a8d8127c"
+            "checksumValue": "cef3e6474d86b3280006b5e64cca18246065f7ded7be46ce3e69e676e87aa624"
           }
         ]
       },
@@ -444,7 +444,7 @@
         "checksums": [
           {
             "algorithm": "SHA256",
-            "checksumValue": "78181e4db90013d6266afe778eda8d6ff8978dc1083ee7c1e0e7a3abb8505b59"
+            "checksumValue": "ca06f01c842e44212e5688f68b8321ea79b8da7137a7c93c4bf6462ea7a60bc8"
           }
         ]
       },
@@ -460,7 +460,7 @@
         "checksums": [
           {
             "algorithm": "SHA256",
-            "checksumValue": "a46bcc94436e553ecd9b04360843784ee56f0461b6a8c54d0d2d2461bc38b790"
+            "checksumValue": "6341eac0ff8470fb22ecd1354c974137917214f77a1d8c2da33e33d1cc6bb165"
           }
         ]
       },
@@ -476,7 +476,7 @@
         "checksums": [
           {
             "algorithm": "SHA256",
-            "checksumValue": "cfd15a3cb03c7dd6b00a3b00eec8f6352096d46b8e9c8a2227ddc1a3922c66e5"
+            "checksumValue": "890b4a674cd7b052b8b0c08e3340031bae6f558f4b7e1de9c9d6c22e02768dc3"
           }
         ]
       },
@@ -492,7 +492,7 @@
         "checksums": [
           {
             "algorithm": "SHA256",
-            "checksumValue": "89739fad97e29c9f71ff1549111f7d3f7459e422693caa4287ebe4b8c00d2d16"
+            "checksumValue": "79054edb4ce37b4ef857c171d9d73b18233cc6aff57908c8ef960637be9ff9a9"
           }
         ]
       },
@@ -508,7 +508,7 @@
         "checksums": [
           {
             "algorithm": "SHA256",
-            "checksumValue": "7d7820f09ac84ec4663e22891dae4af579cdf1ab9dc59730e544b94773e6a819"
+            "checksumValue": "2a7bf73b1557209cdbf682e21b5268a7dc74adb1eac46e83ac35f0ff65724903"
           }
         ]
       },

--- a/workspace/docs/release-manifest.json
+++ b/workspace/docs/release-manifest.json
@@ -72,7 +72,7 @@
       {
         "name": "@deepwatch/cli",
         "version": "0.1.0",
-        "integrity": "sha256:5604851423309410849c5a9dcbc4a96b616fe661e02965df0bd20e25fce2fa0c",
+        "integrity": "sha256:78bca60c85f351f7730f8e1d72df0f6994284676d4a0d5dd1e86edb115f0c65b",
         "sourceFiles": 12
       },
       {
@@ -189,7 +189,7 @@
       "creators": [
         "Tool: watch-gen-release-manifest"
       ],
-      "created": "2026-09-06T17:00:46Z"
+      "created": "2026-09-06T18:01:44Z"
     },
     "packages": [
       {
@@ -252,7 +252,7 @@
         "checksums": [
           {
             "algorithm": "SHA256",
-            "checksumValue": "5604851423309410849c5a9dcbc4a96b616fe661e02965df0bd20e25fce2fa0c"
+            "checksumValue": "78bca60c85f351f7730f8e1d72df0f6994284676d4a0d5dd1e86edb115f0c65b"
           }
         ]
       },

--- a/workspace/docs/release-manifest.json
+++ b/workspace/docs/release-manifest.json
@@ -66,7 +66,7 @@
       {
         "name": "@deepwatch/dsh-bundle",
         "version": "0.1.0",
-        "integrity": "sha256:eca326d2ec31ee48316ed0c8fd05c06d08bd7d936f8e3c67ab80a22ad21b8a5a",
+        "integrity": "sha256:9cb189989815d4813eb7a6f285ac292edf9061203e6507b3a2d2c8fece1410a3",
         "sourceFiles": 7
       },
       {
@@ -189,7 +189,7 @@
       "creators": [
         "Tool: watch-gen-release-manifest"
       ],
-      "created": "2026-09-06T11:53:38Z"
+      "created": "2026-09-06T16:43:44Z"
     },
     "packages": [
       {
@@ -236,7 +236,7 @@
         "checksums": [
           {
             "algorithm": "SHA256",
-            "checksumValue": "eca326d2ec31ee48316ed0c8fd05c06d08bd7d936f8e3c67ab80a22ad21b8a5a"
+            "checksumValue": "9cb189989815d4813eb7a6f285ac292edf9061203e6507b3a2d2c8fece1410a3"
           }
         ]
       },

--- a/workspace/packages/watch/adapters/README.md
+++ b/workspace/packages/watch/adapters/README.md
@@ -2,10 +2,13 @@
 
 Optional adapters: Obsidian vaults and LLMWiki bundles. Watch works fully without either.
 
-Part of **DeepWatch** — the Web and Desktop agent product built on the
-official [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)
-packages and powered by [Watch Skill](https://github.com/oxbshw/watch-skill) for perception, evidence,
-memory and independent verification.
+Part of **DeepWatch** — the agent workspace built on the official
+[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)
+and powered by [Watch Skill](https://github.com/oxbshw/watch-skill) for perception, evidence, memory and
+independent verification.
+
+> **Optional extra — nothing requires it.**
+> Anyone exporting Watch's memory into another tool. Nothing depends on it.
 
 ## Exports
 
@@ -27,6 +30,16 @@ Rarely on its own. [`@deepwatch/dsh-bundle`](https://github.com/oxbshw/watch-ski
 composes this package with the rest of DeepWatch and is what a profile
 normally depends on; installing this one directly is for embedding a
 single piece in a composition you control.
+
+## Example
+
+Export the wiki as an Obsidian vault:
+
+```sh
+import { buildWiki, toVault } from '@deepwatch/dsh-adapters'
+
+const vault = toVault(buildWiki(records), { name: 'Watch' })
+```
 
 ## Requirements
 
@@ -52,10 +65,12 @@ workspace boundary and the host's permissions, not by this flag.
 
 ## Where this fits
 
-These packages are composed together; installing one on its own is rarely
-what you want. The whole picture, the gates it has to pass, and how to run
-DeepWatch is in the
-[workspace README](https://github.com/oxbshw/watch-skill/tree/main/workspace#readme).
+Obsidian vaults and LLMWiki bundles, generated from the ledger. An edit in an exported vault is a proposal, never a change: Watch is the record and the folder is a copy.
+
+The twenty packages and how they compose:
+[the package map](https://github.com/oxbshw/watch-skill/blob/main/workspace/docs/packages.md).
+Running DeepWatch, and the gates a change has to pass:
+[the workspace README](https://github.com/oxbshw/watch-skill/tree/main/workspace#readme).
 
 ## Attribution
 

--- a/workspace/packages/watch/adapters/README.md
+++ b/workspace/packages/watch/adapters/README.md
@@ -35,6 +35,8 @@ single piece in a composition you control.
 
 Export the wiki as an Obsidian vault:
 
+> Pending the `deepwatch-v0.1.0` release — see Install above.
+
 ```sh
 import { buildWiki, toVault } from '@deepwatch/dsh-adapters'
 

--- a/workspace/packages/watch/brand/README.md
+++ b/workspace/packages/watch/brand/README.md
@@ -2,10 +2,13 @@
 
 Browser half: the Watch product identity and its semantic status tokens
 
-Part of **DeepWatch** — the Web and Desktop agent product built on the
-official [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)
-packages and powered by [Watch Skill](https://github.com/oxbshw/watch-skill) for perception, evidence,
-memory and independent verification.
+Part of **DeepWatch** — the agent workspace built on the official
+[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)
+and powered by [Watch Skill](https://github.com/oxbshw/watch-skill) for perception, evidence, memory and
+independent verification.
+
+> **Browser half — runs in the workspace UI.**
+> Composed by the bundle. Install it directly to build a surface that matches Watch's identity.
 
 ## Exports
 
@@ -61,10 +64,12 @@ workspace boundary and the host's permissions, not by this flag.
 
 ## Where this fits
 
-These packages are composed together; installing one on its own is rarely
-what you want. The whole picture, the gates it has to pass, and how to run
-DeepWatch is in the
-[workspace README](https://github.com/oxbshw/watch-skill/tree/main/workspace#readme).
+The product identity and the semantic status tokens every other surface reads, plus the attribution and independence statements the product renders.
+
+The twenty packages and how they compose:
+[the package map](https://github.com/oxbshw/watch-skill/blob/main/workspace/docs/packages.md).
+Running DeepWatch, and the gates a change has to pass:
+[the workspace README](https://github.com/oxbshw/watch-skill/tree/main/workspace#readme).
 
 ## Attribution
 

--- a/workspace/packages/watch/bundle/README.md
+++ b/workspace/packages/watch/bundle/README.md
@@ -29,10 +29,9 @@ For the full experience, install the engine too:
 pip install watch-skill
 ```
 
-`watch-skill` is on PyPI and installs today; the newest published version is
-1.2.0, and the 1.4.0 this bundle is built against is published by the
-`core-v1.4.0` release. The Bridge finds the executable on `PATH` and connects
-on its own.
+`watch-skill` is on PyPI and the newest published version is 1.4.0 — the
+release this bundle is built against. The Bridge finds the executable on
+`PATH` and connects on its own.
 
 ## Stability
 

--- a/workspace/packages/watch/cli/README.md
+++ b/workspace/packages/watch/cli/README.md
@@ -36,6 +36,8 @@ npm install @deepwatch/cli
 
 Set up once, then serve a workspace:
 
+> Pending the `deepwatch-v0.1.0` release — see Install above.
+
 ```sh
 npm install -g @deepwatch/cli
 deepwatch doctor              # what is installed, what is missing

--- a/workspace/packages/watch/cli/README.md
+++ b/workspace/packages/watch/cli/README.md
@@ -2,10 +2,13 @@
 
 DeepWatch — set up and run the agent workspace built on DeepSeek Harness and powered by Watch Skill
 
-Part of **DeepWatch** — the Web and Desktop agent product built on the
-official [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)
-packages and powered by [Watch Skill](https://github.com/oxbshw/watch-skill) for perception, evidence,
-memory and independent verification.
+Part of **DeepWatch** — the agent workspace built on the official
+[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)
+and powered by [Watch Skill](https://github.com/oxbshw/watch-skill) for perception, evidence, memory and
+independent verification.
+
+> **Installed on purpose.**
+> Anyone who wants the whole DeepWatch workspace and does not already run a DeepSeek Harness. This is the package behind the `deepwatch` command.
 
 ## Exports
 
@@ -29,15 +32,23 @@ Provided by the host rather than installed here:
 npm install @deepwatch/cli
 ```
 
-Rarely on its own. [`@deepwatch/dsh-bundle`](https://github.com/oxbshw/watch-skill/tree/main/workspace/packages/watch/bundle#readme)
-composes this package with the rest of DeepWatch and is what a profile
-normally depends on; installing this one directly is for embedding a
-single piece in a composition you control.
+## Example
+
+Set up once, then serve a workspace:
+
+```sh
+npm install -g @deepwatch/cli
+deepwatch doctor              # what is installed, what is missing
+deepwatch setup               # build the runtime, compose the profile
+deepwatch web --workspace ./my-project
+```
 
 ## Requirements
 
 - Node `^22.19.0 || >=24.0.0`
 - The peers above, supplied by the host composition
+
+Node ≥ 22.19. Python 3.11–3.13 with `watch-skill` installed for the perception and verification half; `deepwatch doctor` reports what is missing and `deepwatch setup` offers to fetch what it can.
 
 ## Stability
 
@@ -59,10 +70,12 @@ workspace boundary and the host's permissions, not by this flag.
 
 ## Where this fits
 
-These packages are composed together; installing one on its own is rarely
-what you want. The whole picture, the gates it has to pass, and how to run
-DeepWatch is in the
-[workspace README](https://github.com/oxbshw/watch-skill/tree/main/workspace#readme).
+It composes `@deepwatch/dsh-bundle` into a DeepSeek Harness profile, manages the runtime that profile needs, and serves it. Everything it installs is one of the other nineteen packages.
+
+The twenty packages and how they compose:
+[the package map](https://github.com/oxbshw/watch-skill/blob/main/workspace/docs/packages.md).
+Running DeepWatch, and the gates a change has to pass:
+[the workspace README](https://github.com/oxbshw/watch-skill/tree/main/workspace#readme).
 
 ## Attribution
 

--- a/workspace/packages/watch/cli/src/launch.ts
+++ b/workspace/packages/watch/cli/src/launch.ts
@@ -168,22 +168,33 @@ export async function runWeb(invocation: Invocation): Promise<number> {
 /**
  * `deepwatch desktop`.
  *
- * The desktop application is distributed as a signed installer per platform
- * rather than through npm, so this does not download one. It launches an
- * installed DeepWatch if `DEEPWATCH_DESKTOP_BIN` names it, and otherwise says
- * where to get it — which is the honest answer for a command that cannot
- * fabricate an application.
+ * This does not download an application, and it used to say the reason was
+ * that the application is "distributed as a signed installer per platform" —
+ * which sent a person to "the project releases" to find one. There is not one.
+ * No release has ever carried a desktop asset, `@deepwatch/desktop` is
+ * `private`, and the `build` block in its manifest is electron-builder
+ * configuration for a builder that is not a dependency and that no script
+ * invokes. The Electron shell starts and its context isolation holds
+ * (`npm run smoke:desktop` proves that on a machine with a desktop session),
+ * and none of that is a download.
+ *
+ * So the message says the true thing instead: this release does not distribute
+ * a desktop application, `deepwatch web` is the supported way to run the same
+ * workspace, and `DEEPWATCH_DESKTOP_BIN` remains the escape hatch for somebody
+ * who has built the shell themselves. A command that points at a file nobody
+ * produces is worse than one that admits the gap.
  */
 export function runDesktop(invocation: Invocation): Promise<number> {
   const binary = process.env['DEEPWATCH_DESKTOP_BIN']
   if (typeof binary !== 'string' || binary === '') {
     process.stderr.write(
-      'deepwatch: the DeepWatch desktop app is installed from a platform installer,\n'
-      + '           not from npm, so there is nothing here to start.\n\n'
-      + '           Install it from the project releases, then run it from your\n'
-      + '           applications list — or set DEEPWATCH_DESKTOP_BIN to its\n'
-      + '           executable and run this again.\n\n'
-      + '           `deepwatch web` runs the same workspace in your browser now.\n')
+      'deepwatch: this release does not distribute a desktop application, so there\n'
+      + '           is nothing here to start. No installer is published and none is\n'
+      + '           built from this repository.\n\n'
+      + '           `deepwatch web` runs the same workspace in your browser, with\n'
+      + '           the same profile and the same evidence.\n\n'
+      + '           If you have built the Electron shell yourself, set\n'
+      + '           DEEPWATCH_DESKTOP_BIN to its executable and run this again.\n')
     return Promise.resolve(2)
   }
   // The desktop shell hosts the same Harness, so it needs the same one root.

--- a/workspace/packages/watch/client-evidence/README.md
+++ b/workspace/packages/watch/client-evidence/README.md
@@ -2,10 +2,13 @@
 
 Browser half: verdict and evidence presentation for Watch tool results
 
-Part of **DeepWatch** — the Web and Desktop agent product built on the
-official [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)
-packages and powered by [Watch Skill](https://github.com/oxbshw/watch-skill) for perception, evidence,
-memory and independent verification.
+Part of **DeepWatch** — the agent workspace built on the official
+[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)
+and powered by [Watch Skill](https://github.com/oxbshw/watch-skill) for perception, evidence, memory and
+independent verification.
+
+> **Browser half — runs in the workspace UI.**
+> Composed by the bundle and loaded by the DSH client loader.
 
 ## Exports
 
@@ -64,10 +67,12 @@ workspace boundary and the host's permissions, not by this flag.
 
 ## Where this fits
 
-These packages are composed together; installing one on its own is rarely
-what you want. The whole picture, the gates it has to pass, and how to run
-DeepWatch is in the
-[workspace README](https://github.com/oxbshw/watch-skill/tree/main/workspace#readme).
+How a verdict looks: the result card, the check list, the contract digest, and Compare for two runs of the same contract. It presents what Core decided and decides nothing itself.
+
+The twenty packages and how they compose:
+[the package map](https://github.com/oxbshw/watch-skill/blob/main/workspace/docs/packages.md).
+Running DeepWatch, and the gates a change has to pass:
+[the workspace README](https://github.com/oxbshw/watch-skill/tree/main/workspace#readme).
 
 ## Attribution
 

--- a/workspace/packages/watch/client-memory/README.md
+++ b/workspace/packages/watch/client-memory/README.md
@@ -2,10 +2,13 @@
 
 Browser half: the Memory product surfaces — taste, timeline, wiki, decisions, lessons, failures, sources
 
-Part of **DeepWatch** — the Web and Desktop agent product built on the
-official [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)
-packages and powered by [Watch Skill](https://github.com/oxbshw/watch-skill) for perception, evidence,
-memory and independent verification.
+Part of **DeepWatch** — the agent workspace built on the official
+[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)
+and powered by [Watch Skill](https://github.com/oxbshw/watch-skill) for perception, evidence, memory and
+independent verification.
+
+> **Browser half — runs in the workspace UI.**
+> Composed by the bundle and loaded by the DSH client loader.
 
 ## Exports
 
@@ -63,10 +66,12 @@ workspace boundary and the host's permissions, not by this flag.
 
 ## Where this fits
 
-These packages are composed together; installing one on its own is rarely
-what you want. The whole picture, the gates it has to pass, and how to run
-DeepWatch is in the
-[workspace README](https://github.com/oxbshw/watch-skill/tree/main/workspace#readme).
+The Memory surfaces — taste, timeline, wiki, decisions, lessons, failures and sources — over the ledger `@deepwatch/dsh-memory` keeps.
+
+The twenty packages and how they compose:
+[the package map](https://github.com/oxbshw/watch-skill/blob/main/workspace/docs/packages.md).
+Running DeepWatch, and the gates a change has to pass:
+[the workspace README](https://github.com/oxbshw/watch-skill/tree/main/workspace#readme).
 
 ## Attribution
 

--- a/workspace/packages/watch/client-remotes/README.md
+++ b/workspace/packages/watch/client-remotes/README.md
@@ -2,10 +2,13 @@
 
 Client composition: mounts Watch's generated Typert Remote into ctx.remote
 
-Part of **DeepWatch** — the Web and Desktop agent product built on the
-official [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)
-packages and powered by [Watch Skill](https://github.com/oxbshw/watch-skill) for perception, evidence,
-memory and independent verification.
+Part of **DeepWatch** — the agent workspace built on the official
+[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)
+and powered by [Watch Skill](https://github.com/oxbshw/watch-skill) for perception, evidence, memory and
+independent verification.
+
+> **Browser half — runs in the workspace UI.**
+> Composed by the bundle and loaded by the DSH client loader.
 
 ## Exports
 
@@ -60,10 +63,12 @@ workspace boundary and the host's permissions, not by this flag.
 
 ## Where this fits
 
-These packages are composed together; installing one on its own is rarely
-what you want. The whole picture, the gates it has to pass, and how to run
-DeepWatch is in the
-[workspace README](https://github.com/oxbshw/watch-skill/tree/main/workspace#readme).
+Mounts Watch's generated Typert Remote into `ctx.remote`, so every client call reaches the host through one generated, type-checked surface instead of hand-written fetches.
+
+The twenty packages and how they compose:
+[the package map](https://github.com/oxbshw/watch-skill/blob/main/workspace/docs/packages.md).
+Running DeepWatch, and the gates a change has to pass:
+[the workspace README](https://github.com/oxbshw/watch-skill/tree/main/workspace#readme).
 
 ## Attribution
 

--- a/workspace/packages/watch/client-settings/README.md
+++ b/workspace/packages/watch/client-settings/README.md
@@ -2,10 +2,13 @@
 
 Browser half: the Watch Technology & Capability Center — role bindings, engines, sources, memory, verification, diagnostics, about
 
-Part of **DeepWatch** — the Web and Desktop agent product built on the
-official [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)
-packages and powered by [Watch Skill](https://github.com/oxbshw/watch-skill) for perception, evidence,
-memory and independent verification.
+Part of **DeepWatch** — the agent workspace built on the official
+[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)
+and powered by [Watch Skill](https://github.com/oxbshw/watch-skill) for perception, evidence, memory and
+independent verification.
+
+> **Browser half — runs in the workspace UI.**
+> Composed by the bundle and loaded by the DSH client loader.
 
 ## Exports
 
@@ -63,10 +66,12 @@ workspace boundary and the host's permissions, not by this flag.
 
 ## Where this fits
 
-These packages are composed together; installing one on its own is rarely
-what you want. The whole picture, the gates it has to pass, and how to run
-DeepWatch is in the
-[workspace README](https://github.com/oxbshw/watch-skill/tree/main/workspace#readme).
+The Technology & Capability Center: role bindings, engines, sources, memory, verification and diagnostics. This is the screen that says what is ready and what is missing.
+
+The twenty packages and how they compose:
+[the package map](https://github.com/oxbshw/watch-skill/blob/main/workspace/docs/packages.md).
+Running DeepWatch, and the gates a change has to pass:
+[the workspace README](https://github.com/oxbshw/watch-skill/tree/main/workspace#readme).
 
 ## Attribution
 

--- a/workspace/packages/watch/contracts/README.md
+++ b/workspace/packages/watch/contracts/README.md
@@ -2,10 +2,13 @@
 
 Watch Bridge wire contracts shared by the Host plugins and the browser halves
 
-Part of **DeepWatch** — the Web and Desktop agent product built on the
-official [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)
-packages and powered by [Watch Skill](https://github.com/oxbshw/watch-skill) for perception, evidence,
-memory and independent verification.
+Part of **DeepWatch** — the agent workspace built on the official
+[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)
+and powered by [Watch Skill](https://github.com/oxbshw/watch-skill) for perception, evidence, memory and
+independent verification.
+
+> **Shared contract — depended on by both halves.**
+> Anyone implementing either side of the Bridge — a host plugin, a browser half, or a client of your own.
 
 ## Exports
 
@@ -36,6 +39,8 @@ single piece in a composition you control.
 
 - Node `^22.19.0 || >=24.0.0`
 
+None. Types and schemas only; it pulls in nothing at runtime.
+
 ## Stability
 
 `0.1.0` — a stable release.
@@ -56,10 +61,12 @@ workspace boundary and the host's permissions, not by this flag.
 
 ## Where this fits
 
-These packages are composed together; installing one on its own is rarely
-what you want. The whole picture, the gates it has to pass, and how to run
-DeepWatch is in the
-[workspace README](https://github.com/oxbshw/watch-skill/tree/main/workspace#readme).
+The wire shapes both halves agree on. Changing a shape here changes both sides at once, which is the reason it is a package rather than two copies.
+
+The twenty packages and how they compose:
+[the package map](https://github.com/oxbshw/watch-skill/blob/main/workspace/docs/packages.md).
+Running DeepWatch, and the gates a change has to pass:
+[the workspace README](https://github.com/oxbshw/watch-skill/tree/main/workspace#readme).
 
 ## Attribution
 

--- a/workspace/packages/watch/core-bridge/README.md
+++ b/workspace/packages/watch/core-bridge/README.md
@@ -2,10 +2,13 @@
 
 Host plugin: the typed Bridge between DeepSeek Harness and Watch Core
 
-Part of **DeepWatch** — the Web and Desktop agent product built on the
-official [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)
-packages and powered by [Watch Skill](https://github.com/oxbshw/watch-skill) for perception, evidence,
-memory and independent verification.
+Part of **DeepWatch** — the agent workspace built on the official
+[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)
+and powered by [Watch Skill](https://github.com/oxbshw/watch-skill) for perception, evidence, memory and
+independent verification.
+
+> **Host plugin — runs beside the agent in the DSH process.**
+> Composed by the bundle. Install it directly only to speak to Watch Core from a host of your own.
 
 ## Exports
 
@@ -35,10 +38,30 @@ composes this package with the rest of DeepWatch and is what a profile
 normally depends on; installing this one directly is for embedding a
 single piece in a composition you control.
 
+## Configuration
+
+Supplied by the host when it mounts this plugin.
+
+| Option | Type | |
+| --- | --- | --- |
+| `transport` | `'auto' | 'stdio' | 'mock'` | How to reach Watch Core. |
+| `command` | `string` | Executable that starts Watch Core in Bridge mode. |
+| `args` | `string[]` |  |
+| `cwd` | `string` | Working directory for the child. |
+| `startupTimeoutMs` | `number` |  |
+| `requestTimeoutMs` | `number` | Deadline applied to a request that does not carry its own. |
+| `dataDir` | `string` | Profile-scoped data directory for the engine. |
+| `autoConnect` | `boolean` | Connect during plugin activation rather than on first use. |
+| `failuresBeforeOpen` | `number` | Consecutive connection failures before the Bridge stops trying. |
+| `initialCooldownMs` | `number` | First cooldown after the circuit opens. |
+| `maxCooldownMs` | `number` | Ceiling for the cooldown, so backoff cannot grow without bound. |
+
 ## Requirements
 
 - Node `^22.19.0 || >=24.0.0`
 - The peers above, supplied by the host composition
+
+`watch-skill` reachable on `PATH`, or an explicit `command`. Without one the Bridge reports `core_missing` and leaves the workspace usable with Watch features disabled — it does not fall back to a mock.
 
 ## Stability
 
@@ -60,10 +83,12 @@ workspace boundary and the host's permissions, not by this flag.
 
 ## Where this fits
 
-These packages are composed together; installing one on its own is rarely
-what you want. The whole picture, the gates it has to pass, and how to run
-DeepWatch is in the
-[workspace README](https://github.com/oxbshw/watch-skill/tree/main/workspace#readme).
+The only thing that talks to Watch Core. Every other package reaches Core through it, which is what makes Core the sole source of a verdict.
+
+The twenty packages and how they compose:
+[the package map](https://github.com/oxbshw/watch-skill/blob/main/workspace/docs/packages.md).
+Running DeepWatch, and the gates a change has to pass:
+[the workspace README](https://github.com/oxbshw/watch-skill/tree/main/workspace#readme).
 
 ## Attribution
 

--- a/workspace/packages/watch/library/README.md
+++ b/workspace/packages/watch/library/README.md
@@ -2,10 +2,13 @@
 
 Library — sources, revisions, index state, search, facets and collections
 
-Part of **DeepWatch** — the Web and Desktop agent product built on the
-official [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)
-packages and powered by [Watch Skill](https://github.com/oxbshw/watch-skill) for perception, evidence,
-memory and independent verification.
+Part of **DeepWatch** — the agent workspace built on the official
+[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)
+and powered by [Watch Skill](https://github.com/oxbshw/watch-skill) for perception, evidence, memory and
+independent verification.
+
+> **Host plugin — runs beside the agent in the DSH process.**
+> Composed by the bundle.
 
 ## Exports
 
@@ -47,6 +50,8 @@ single piece in a composition you control.
 - Node `^22.19.0 || >=24.0.0`
 - The peers above, supplied by the host composition
 
+A Bridge connected to Core, and `libraryRoots` naming the directories the index may read — empty by default, so a deployment that has not said where its evidence lives gets a tool reporting nothing to search rather than one guessing.
+
 ## Stability
 
 `0.1.0` — a stable release.
@@ -67,10 +72,12 @@ workspace boundary and the host's permissions, not by this flag.
 
 ## Where this fits
 
-These packages are composed together; installing one on its own is rarely
-what you want. The whole picture, the gates it has to pass, and how to run
-DeepWatch is in the
-[workspace README](https://github.com/oxbshw/watch-skill/tree/main/workspace#readme).
+The catalogue behind the Library screen: sources, revisions, index state, search, facets and collections.
+
+The twenty packages and how they compose:
+[the package map](https://github.com/oxbshw/watch-skill/blob/main/workspace/docs/packages.md).
+Running DeepWatch, and the gates a change has to pass:
+[the workspace README](https://github.com/oxbshw/watch-skill/tree/main/workspace#readme).
 
 ## Attribution
 

--- a/workspace/packages/watch/live/README.md
+++ b/workspace/packages/watch/live/README.md
@@ -2,10 +2,13 @@
 
 Live mode — cursors, gaps, clocks, reconnect and a bounded buffer
 
-Part of **DeepWatch** — the Web and Desktop agent product built on the
-official [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)
-packages and powered by [Watch Skill](https://github.com/oxbshw/watch-skill) for perception, evidence,
-memory and independent verification.
+Part of **DeepWatch** — the agent workspace built on the official
+[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)
+and powered by [Watch Skill](https://github.com/oxbshw/watch-skill) for perception, evidence, memory and
+independent verification.
+
+> **Host plugin — runs beside the agent in the DSH process.**
+> Composed by the bundle. Needed for live and browser sessions.
 
 ## Exports
 
@@ -46,6 +49,8 @@ single piece in a composition you control.
 - Node `^22.19.0 || >=24.0.0`
 - The peers above, supplied by the host composition
 
+Core built with the `[loop]` extra, and a browser installed by `playwright install chromium`, for anything that drives a page.
+
 ## Stability
 
 `0.1.0` — a stable release.
@@ -66,10 +71,12 @@ workspace boundary and the host's permissions, not by this flag.
 
 ## Where this fits
 
-These packages are composed together; installing one on its own is rarely
-what you want. The whole picture, the gates it has to pass, and how to run
-DeepWatch is in the
-[workspace README](https://github.com/oxbshw/watch-skill/tree/main/workspace#readme).
+One clock across streams, with cursors, declared gaps, a bounded buffer and a reconnect policy — so "what was on screen when that was said" has an answer rather than a guess.
+
+The twenty packages and how they compose:
+[the package map](https://github.com/oxbshw/watch-skill/blob/main/workspace/docs/packages.md).
+Running DeepWatch, and the gates a change has to pass:
+[the workspace README](https://github.com/oxbshw/watch-skill/tree/main/workspace#readme).
 
 ## Attribution
 

--- a/workspace/packages/watch/memory/README.md
+++ b/workspace/packages/watch/memory/README.md
@@ -2,10 +2,13 @@
 
 Host plugin: durable, correctable, scoped memory over an append-only event ledger
 
-Part of **DeepWatch** — the Web and Desktop agent product built on the
-official [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)
-packages and powered by [Watch Skill](https://github.com/oxbshw/watch-skill) for perception, evidence,
-memory and independent verification.
+Part of **DeepWatch** — the agent workspace built on the official
+[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)
+and powered by [Watch Skill](https://github.com/oxbshw/watch-skill) for perception, evidence, memory and
+independent verification.
+
+> **Host plugin — runs beside the agent in the DSH process.**
+> Composed by the bundle. Off unless a profile turns it on.
 
 ## Exports
 
@@ -37,10 +40,24 @@ composes this package with the rest of DeepWatch and is what a profile
 normally depends on; installing this one directly is for embedding a
 single piece in a composition you control.
 
+## Configuration
+
+Supplied by the host when it mounts this plugin.
+
+| Option | Type | |
+| --- | --- | --- |
+| `mode` | `MemoryMode` | What this profile permits. |
+| `directory` | `string` | Directory for the ledger and the Markdown projections. |
+| `inferredThreshold` | `number` | Confidence at or above which an inferred, low-impact memory acts. |
+| `tokenBudget` | `number` | Hard ceiling on what memory may cost one turn. |
+| `writeProjections` | `boolean` | Write `taste.md` and friends whenever memory changes. |
+
 ## Requirements
 
 - Node `^22.19.0 || >=24.0.0`
 - The peers above, supplied by the host composition
+
+A writable directory for the ledger. The store is plaintext; it is created owner-only where the operating system enforces file modes, and there is no encryption at rest in this release.
 
 ## Stability
 
@@ -62,10 +79,12 @@ workspace boundary and the host's permissions, not by this flag.
 
 ## Where this fits
 
-These packages are composed together; installing one on its own is rarely
-what you want. The whole picture, the gates it has to pass, and how to run
-DeepWatch is in the
-[workspace README](https://github.com/oxbshw/watch-skill/tree/main/workspace#readme).
+An append-only event ledger under the workspace boundary. `@deepwatch/dsh-wiki` projects it into pages and `@deepwatch/dsh-client-memory` presents it.
+
+The twenty packages and how they compose:
+[the package map](https://github.com/oxbshw/watch-skill/blob/main/workspace/docs/packages.md).
+Running DeepWatch, and the gates a change has to pass:
+[the workspace README](https://github.com/oxbshw/watch-skill/tree/main/workspace#readme).
 
 ## Attribution
 

--- a/workspace/packages/watch/sdk/README.md
+++ b/workspace/packages/watch/sdk/README.md
@@ -42,6 +42,8 @@ single piece in a composition you control.
 
 The four verbs a capability gets:
 
+> Pending the `deepwatch-v0.1.0` release — see Install above.
+
 ```sh
 import { declare, probe, observe, request } from '@deepwatch/dsh-sdk'
 ```

--- a/workspace/packages/watch/sdk/README.md
+++ b/workspace/packages/watch/sdk/README.md
@@ -2,10 +2,13 @@
 
 The third-party Watch capability developer path — declare, probe, observe, request
 
-Part of **DeepWatch** — the Web and Desktop agent product built on the
-official [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)
-packages and powered by [Watch Skill](https://github.com/oxbshw/watch-skill) for perception, evidence,
-memory and independent verification.
+Part of **DeepWatch** — the agent workspace built on the official
+[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)
+and powered by [Watch Skill](https://github.com/oxbshw/watch-skill) for perception, evidence, memory and
+independent verification.
+
+> **Optional extra — nothing requires it.**
+> Third parties building a Watch capability of their own.
 
 ## Exports
 
@@ -35,10 +38,20 @@ composes this package with the rest of DeepWatch and is what a profile
 normally depends on; installing this one directly is for embedding a
 single piece in a composition you control.
 
+## Example
+
+The four verbs a capability gets:
+
+```sh
+import { declare, probe, observe, request } from '@deepwatch/dsh-sdk'
+```
+
 ## Requirements
 
 - Node `^22.19.0 || >=24.0.0`
 - The peers above, supplied by the host composition
+
+A DSH host to mount into.
 
 ## Stability
 
@@ -60,10 +73,12 @@ workspace boundary and the host's permissions, not by this flag.
 
 ## Where this fits
 
-These packages are composed together; installing one on its own is rarely
-what you want. The whole picture, the gates it has to pass, and how to run
-DeepWatch is in the
-[workspace README](https://github.com/oxbshw/watch-skill/tree/main/workspace#readme).
+The supported extension path: declare a capability, probe whether its prerequisites hold, observe what happens, request work. It is how a capability joins the composition without patching it.
+
+The twenty packages and how they compose:
+[the package map](https://github.com/oxbshw/watch-skill/blob/main/workspace/docs/packages.md).
+Running DeepWatch, and the gates a change has to pass:
+[the workspace README](https://github.com/oxbshw/watch-skill/tree/main/workspace#readme).
 
 ## Attribution
 

--- a/workspace/packages/watch/technology/README.md
+++ b/workspace/packages/watch/technology/README.md
@@ -2,10 +2,13 @@
 
 Technology descriptors, capability lifecycle, and role bindings over DSH Models and Providers
 
-Part of **DeepWatch** — the Web and Desktop agent product built on the
-official [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)
-packages and powered by [Watch Skill](https://github.com/oxbshw/watch-skill) for perception, evidence,
-memory and independent verification.
+Part of **DeepWatch** — the agent workspace built on the official
+[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)
+and powered by [Watch Skill](https://github.com/oxbshw/watch-skill) for perception, evidence, memory and
+independent verification.
+
+> **Host plugin — runs beside the agent in the DSH process.**
+> Composed by the bundle.
 
 ## Exports
 
@@ -49,6 +52,8 @@ single piece in a composition you control.
 - Node `^22.19.0 || >=24.0.0`
 - The peers above, supplied by the host composition
 
+DSH Models and Providers configured in the host profile.
+
 ## Stability
 
 `0.1.0` — a stable release.
@@ -69,10 +74,12 @@ workspace boundary and the host's permissions, not by this flag.
 
 ## Where this fits
 
-These packages are composed together; installing one on its own is rarely
-what you want. The whole picture, the gates it has to pass, and how to run
-DeepWatch is in the
-[workspace README](https://github.com/oxbshw/watch-skill/tree/main/workspace#readme).
+Where "this model can see images" is recorded, and where a capability is bound to a role. The Settings surface reads it; nothing else guesses at a model's abilities.
+
+The twenty packages and how they compose:
+[the package map](https://github.com/oxbshw/watch-skill/blob/main/workspace/docs/packages.md).
+Running DeepWatch, and the gates a change has to pass:
+[the workspace README](https://github.com/oxbshw/watch-skill/tree/main/workspace#readme).
 
 ## Attribution
 

--- a/workspace/packages/watch/tenancy/README.md
+++ b/workspace/packages/watch/tenancy/README.md
@@ -2,10 +2,13 @@
 
 Tenants, roles, remote workers, sharing and audit — enforced server-side
 
-Part of **DeepWatch** — the Web and Desktop agent product built on the
-official [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)
-packages and powered by [Watch Skill](https://github.com/oxbshw/watch-skill) for perception, evidence,
-memory and independent verification.
+Part of **DeepWatch** — the agent workspace built on the official
+[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)
+and powered by [Watch Skill](https://github.com/oxbshw/watch-skill) for perception, evidence, memory and
+independent verification.
+
+> **Host plugin — runs beside the agent in the DSH process.**
+> Composed by the bundle. Relevant to a shared or multi-user deployment.
 
 ## Exports
 
@@ -52,10 +55,12 @@ workspace boundary and the host's permissions, not by this flag.
 
 ## Where this fits
 
-These packages are composed together; installing one on its own is rarely
-what you want. The whole picture, the gates it has to pass, and how to run
-DeepWatch is in the
-[workspace README](https://github.com/oxbshw/watch-skill/tree/main/workspace#readme).
+Tenants, roles, remote workers, sharing and audit — decided server-side. A browser half may render a permission; it may not grant one.
+
+The twenty packages and how they compose:
+[the package map](https://github.com/oxbshw/watch-skill/blob/main/workspace/docs/packages.md).
+Running DeepWatch, and the gates a change has to pass:
+[the workspace README](https://github.com/oxbshw/watch-skill/tree/main/workspace#readme).
 
 ## Attribution
 

--- a/workspace/packages/watch/tools/README.md
+++ b/workspace/packages/watch/tools/README.md
@@ -2,10 +2,13 @@
 
 Host plugin: Watch capabilities registered as DeepSeek Harness agent tools
 
-Part of **DeepWatch** — the Web and Desktop agent product built on the
-official [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)
-packages and powered by [Watch Skill](https://github.com/oxbshw/watch-skill) for perception, evidence,
-memory and independent verification.
+Part of **DeepWatch** — the agent workspace built on the official
+[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)
+and powered by [Watch Skill](https://github.com/oxbshw/watch-skill) for perception, evidence, memory and
+independent verification.
+
+> **Host plugin — runs beside the agent in the DSH process.**
+> Composed by the bundle. This is where Watch's capabilities become agent tools.
 
 ## Exports
 
@@ -43,10 +46,29 @@ composes this package with the rest of DeepWatch and is what a profile
 normally depends on; installing this one directly is for embedding a
 single piece in a composition you control.
 
+## Configuration
+
+Supplied by the host when it mounts this plugin.
+
+| Option | Type | |
+| --- | --- | --- |
+| `queryTimeoutMs` | `number` | Deadline for a source query, which may involve perception work. |
+| `verifyTimeoutMs` | `number` | Deadline for one verification contract. |
+| `readTimeoutMs` | `number` | Deadline for a search or a moment lookup. |
+| `coldReadTimeoutMs` | `number` | Deadline for the first read after the engine connects. |
+| `liveStartTimeoutMs` | `number` | Deadline for starting a live session, which may launch a browser. |
+| `actTimeoutMs` | `number` | Deadline for one browser action, including its re-observation. |
+| `observeTimeoutMs` | `number` | Deadline for a page observation. |
+| `libraryRoots` *(optional)* | `readonly string[]` | Directories the library index may read. |
+| `workspaceScope` *(optional)* | `string` | Which workspace this host answers for. |
+| `receiptsDirectory` *(optional)* | `string` | Where execution receipts are journalled, so they survive a restart. |
+
 ## Requirements
 
 - Node `^22.19.0 || >=24.0.0`
 - The peers above, supplied by the host composition
+
+`@deepwatch/dsh-core-bridge` mounted in the same context.
 
 ## Stability
 
@@ -68,10 +90,12 @@ workspace boundary and the host's permissions, not by this flag.
 
 ## Where this fits
 
-These packages are composed together; installing one on its own is rarely
-what you want. The whole picture, the gates it has to pass, and how to run
-DeepWatch is in the
-[workspace README](https://github.com/oxbshw/watch-skill/tree/main/workspace#readme).
+Registers the 22 `watch_*` tools an agent is offered, and turns each tool call into a receipt. It records what a call did; it never decides whether the work was correct.
+
+The twenty packages and how they compose:
+[the package map](https://github.com/oxbshw/watch-skill/blob/main/workspace/docs/packages.md).
+Running DeepWatch, and the gates a change has to pass:
+[the workspace README](https://github.com/oxbshw/watch-skill/tree/main/workspace#readme).
 
 ## Attribution
 

--- a/workspace/packages/watch/trajectory/README.md
+++ b/workspace/packages/watch/trajectory/README.md
@@ -2,10 +2,13 @@
 
 Watch records inside the DeepSeek Harness Trajectory, with unified selection, deep links and replay
 
-Part of **DeepWatch** — the Web and Desktop agent product built on the
-official [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)
-packages and powered by [Watch Skill](https://github.com/oxbshw/watch-skill) for perception, evidence,
-memory and independent verification.
+Part of **DeepWatch** — the agent workspace built on the official
+[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)
+and powered by [Watch Skill](https://github.com/oxbshw/watch-skill) for perception, evidence, memory and
+independent verification.
+
+> **Host plugin — runs beside the agent in the DSH process.**
+> Composed by the bundle.
 
 ## Exports
 
@@ -52,10 +55,12 @@ workspace boundary and the host's permissions, not by this flag.
 
 ## Where this fits
 
-These packages are composed together; installing one on its own is rarely
-what you want. The whole picture, the gates it has to pass, and how to run
-DeepWatch is in the
-[workspace README](https://github.com/oxbshw/watch-skill/tree/main/workspace#readme).
+Puts Watch records inside the Harness Trajectory, so a receipt, a verdict and the turn that produced them share one selection, one deep link and one replay.
+
+The twenty packages and how they compose:
+[the package map](https://github.com/oxbshw/watch-skill/blob/main/workspace/docs/packages.md).
+Running DeepWatch, and the gates a change has to pass:
+[the workspace README](https://github.com/oxbshw/watch-skill/tree/main/workspace#readme).
 
 ## Attribution
 

--- a/workspace/packages/watch/wiki/README.md
+++ b/workspace/packages/watch/wiki/README.md
@@ -2,10 +2,13 @@
 
 Deterministic workspace wiki projections over the memory ledger
 
-Part of **DeepWatch** — the Web and Desktop agent product built on the
-official [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)
-packages and powered by [Watch Skill](https://github.com/oxbshw/watch-skill) for perception, evidence,
-memory and independent verification.
+Part of **DeepWatch** — the agent workspace built on the official
+[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)
+and powered by [Watch Skill](https://github.com/oxbshw/watch-skill) for perception, evidence, memory and
+independent verification.
+
+> **Host plugin — runs beside the agent in the DSH process.**
+> Composed by the bundle.
 
 ## Exports
 
@@ -32,6 +35,8 @@ single piece in a composition you control.
 
 - Node `^22.19.0 || >=24.0.0`
 
+`@deepwatch/dsh-memory` mounted, since the ledger is what it projects.
+
 ## Stability
 
 `0.1.0` — a stable release.
@@ -52,10 +57,12 @@ workspace boundary and the host's permissions, not by this flag.
 
 ## Where this fits
 
-These packages are composed together; installing one on its own is rarely
-what you want. The whole picture, the gates it has to pass, and how to run
-DeepWatch is in the
-[workspace README](https://github.com/oxbshw/watch-skill/tree/main/workspace#readme).
+Deterministic projections over the memory ledger: the same ledger produces the same pages, so a wiki page is a view and never a second copy of the truth.
+
+The twenty packages and how they compose:
+[the package map](https://github.com/oxbshw/watch-skill/blob/main/workspace/docs/packages.md).
+Running DeepWatch, and the gates a change has to pass:
+[the workspace README](https://github.com/oxbshw/watch-skill/tree/main/workspace#readme).
 
 ## Attribution
 

--- a/workspace/packages/watch/workspace/README.md
+++ b/workspace/packages/watch/workspace/README.md
@@ -2,10 +2,13 @@
 
 Browser half: the DeepWatch product shell — modes, header, inspector and sensory timeline
 
-Part of **DeepWatch** — the Web and Desktop agent product built on the
-official [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)
-packages and powered by [Watch Skill](https://github.com/oxbshw/watch-skill) for perception, evidence,
-memory and independent verification.
+Part of **DeepWatch** — the agent workspace built on the official
+[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)
+and powered by [Watch Skill](https://github.com/oxbshw/watch-skill) for perception, evidence, memory and
+independent verification.
+
+> **Browser half — runs in the workspace UI.**
+> Composed by the bundle and loaded by the DSH client loader.
 
 ## Exports
 
@@ -64,10 +67,12 @@ workspace boundary and the host's permissions, not by this flag.
 
 ## Where this fits
 
-These packages are composed together; installing one on its own is rarely
-what you want. The whole picture, the gates it has to pass, and how to run
-DeepWatch is in the
-[workspace README](https://github.com/oxbshw/watch-skill/tree/main/workspace#readme).
+The product shell: modes, header, inspector and the sensory timeline every other surface mounts into.
+
+The twenty packages and how they compose:
+[the package map](https://github.com/oxbshw/watch-skill/blob/main/workspace/docs/packages.md).
+Running DeepWatch, and the gates a change has to pass:
+[the workspace README](https://github.com/oxbshw/watch-skill/tree/main/workspace#readme).
 
 ## Attribution
 

--- a/workspace/scripts/first-publish.mjs
+++ b/workspace/scripts/first-publish.mjs
@@ -2,10 +2,34 @@
 /**
  * One-time npm bootstrap for the first @deepwatch publication.
  *
- * Dry-run is the default and never contacts npm. `--check-access` performs
- * the read-only identity/organisation probes. Publishing additionally needs
+ * This exists because of an ordering npm imposes and nothing here can avoid:
+ * a Trusted Publisher is configured *on a package*, and a package that has
+ * never been published has no page to configure it on. `release-deepwatch.yml`
+ * has no token path at all, deliberately — so the very first version of each
+ * of the twenty has to be uploaded by the release owner, from a machine, with
+ * an ordinary authenticated npm session. Every publication after that one goes
+ * through the workflow, and this script is never run again.
+ *
+ * Dry-run is the default and never contacts npm. `--check-access` performs the
+ * read-only identity and organisation probes. Publishing additionally needs
  * both `--publish` and `--confirm-first-publish`; there is intentionally no
  * environment-variable shortcut.
+ *
+ * **The registry decision is not made here.** It was, once, and it was made
+ * badly: `npm view <name>@<version>` was run, a zero exit meant "already
+ * published, skip" and any non-zero exit meant "absent, publish". Both halves
+ * are wrong in a way that only shows up on a bad day. A version that exists
+ * with *different bytes* was skipped silently, shipping a scope whose halves
+ * came from different commits; and a network blip, an expired credential or a
+ * registry 503 was read as proof of absence, which is how an outage turns into
+ * twenty duplicate uploads. `publish-plan.mjs` already asks the right question
+ * — it compares the registry's integrity against the tarball this run would
+ * upload, and distinguishes absence from failure by npm's own `E404` — so this
+ * script asks it rather than keeping a second, worse opinion.
+ *
+ * One policy, in one place: **publish what is absent, skip what is
+ * demonstrably identical, refuse what conflicts, and stop on anything it
+ * cannot tell apart.**
  */
 
 import { spawnSync } from 'node:child_process'
@@ -15,6 +39,7 @@ import { basename, dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { resolveNpm } from './lib/process.mjs'
+import { buildPlan } from './publish-plan.mjs'
 import { publishOrder } from './publish-order.mjs'
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
@@ -56,6 +81,40 @@ function run(command, args, options = {}) {
 }
 
 /**
+ * npm's own words, with anything secret taken out of them.
+ *
+ * The previous version captured npm's output and threw it away, then told the
+ * operator to "authenticate with a short-lived, 2FA-protected publisher token"
+ * — the same sentence for an expired session, a 403 from the wrong account, a
+ * proxy refusing CONNECT and a registry that was simply down. Three of those
+ * four are not fixed by making a token, and the one message sent the operator
+ * to do the one thing that would not help.
+ *
+ * So npm gets to say what happened. What it must not say is a credential:
+ * bearer tokens, npm's own `npm_` tokens, basic-auth headers and `_authToken`
+ * lines are replaced before anything reaches a console or a state file.
+ *
+ * @param text - raw subprocess output.
+ * @returns the same text with credential-shaped runs replaced.
+ */
+export function sanitize(text) {
+  return String(text)
+    .replace(/\bnpm_[A-Za-z0-9]{16,}/g, 'npm_[redacted]')
+    .replace(/(_authToken\s*=\s*)\S+/gi, '$1[redacted]')
+    .replace(/(authorization\s*:\s*)(bearer|basic)\s+\S+/gi, '$1$2 [redacted]')
+    .replace(/\b[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b/g, '[redacted-jwt]')
+    .replace(/(:\/\/)[^:@/\s]+:[^@/\s]+@/g, '$1[redacted]@')
+    .trim()
+}
+
+/** The last few lines of npm's diagnostics, sanitized, for a console. */
+function diagnostics(result, lines = 12) {
+  const text = sanitize(`${result.stderr}\n${result.stdout}`)
+  if (text === '') return '(npm produced no output)'
+  return text.split('\n').filter(line => line.trim() !== '').slice(-lines).join('\n')
+}
+
+/**
  * The dist-tag a version shape earns, by the same rule the release workflow uses.
  *
  * This was hardcoded to `preview`, which was right while every version was
@@ -79,7 +138,9 @@ export function distTag(version) {
 
 function npm(args) {
   const spec = resolveNpm()
-  if (spec === null) return { code: 1, stdout: '', stderr: 'npm is unavailable' }
+  if (spec === null) {
+    return { code: 1, stdout: '', stderr: 'npm is unavailable: nothing named npm is on PATH' }
+  }
   return run(spec.command, [...spec.prefix, ...args], { cwd: ROOT })
 }
 
@@ -173,26 +234,84 @@ export function verifyArtifacts(directory) {
   return verified
 }
 
+/**
+ * Who npm thinks is running this, and what that says about publishing.
+ *
+ * Two probes, and neither of them is proof of permission. `whoami` proves a
+ * credential resolves to an account. `org ls` proves that account's role in
+ * the organisation the scope belongs to. What neither can prove is that npm
+ * will accept a publish: the scope is empty, so there is no package ACL to
+ * read, and a 2FA policy, a token with the wrong type, or an org billing
+ * state are all invisible to a read-only probe and all decisive at upload.
+ *
+ * This used to claim otherwise. `npm access list packages @deepwatch`
+ * returning zero was recorded as `access: 'verified'` — and for an empty scope
+ * that command succeeds and prints nothing, which is exactly the state where
+ * nothing has been verified at all. The honest report says what was actually
+ * established and names the first upload as the thing that settles the rest.
+ *
+ * Nothing here prints a user name, a token or npm configuration.
+ */
 function checkAccess() {
   const identity = npm(['whoami', '--registry=https://registry.npmjs.org/'])
   if (identity.code !== 0 || identity.stdout.trim() === '') {
-    throw new Error('npm identity check failed; authenticate with a short-lived, 2FA-protected publisher token')
+    throw new Error(
+      'npm has no authenticated identity for registry.npmjs.org.\n'
+      + `npm said:\n${diagnostics(identity)}\n\n`
+      + 'If this is an expired or absent session, sign in as the release owner:\n'
+      + '  npm login --registry=https://registry.npmjs.org/ --auth-type=web\n'
+      + 'If it is a network or proxy failure, the message above says so and a new '
+      + 'credential will not help.')
   }
-  const access = npm(['access', 'list', 'packages', '@deepwatch', '--json'])
-  if (access.code !== 0) {
-    throw new Error('npm organisation access check failed for @deepwatch')
+
+  // The scope is an npm organisation, so the account's role in it is the
+  // closest read-only thing to a publish right. Reported, not asserted.
+  const org = npm(['org', 'ls', 'deepwatch', '--json'])
+  let role = 'unknown'
+  if (org.code === 0) {
+    try {
+      const members = JSON.parse(org.stdout)
+      const mine = Object.entries(members).find(([member]) => member === identity.stdout.trim())
+      role = mine === undefined ? 'not_a_member' : String(mine[1])
+    } catch {
+      role = 'unreadable'
+    }
+  } else {
+    role = 'unreadable'
   }
-  // Deliberately report only that the checks passed. User names, tokens and
-  // npm configuration do not belong in a release artifact.
-  return { identity: 'verified', organisation: '@deepwatch', access: 'verified' }
+
+  const listing = npm(['access', 'list', 'packages', '@deepwatch', '--json'])
+  const scope = listing.code === 0
+    ? (listing.stdout.trim() === '' || listing.stdout.trim() === '{}' ? 'empty' : 'populated')
+    : 'unreadable'
+
+  if (role === 'not_a_member') {
+    throw new Error(
+      'the authenticated account is not a member of the `deepwatch` organisation, '
+      + 'so it cannot publish into the @deepwatch scope.')
+  }
+
+  // Deliberately no user name, no token, no npm configuration: a release
+  // artifact records that the checks ran and what they established, not who.
+  return {
+    identity: 'authenticated',
+    organisation: '@deepwatch',
+    role,
+    scopeListing: scope,
+    publishPermission: 'not_provable_before_upload',
+    note: 'whoami and org membership are read-only probes. npm settles publish '
+      + 'permission at the first upload, and that upload is the first package in '
+      + 'the order below.',
+  }
 }
 
 function initialState(mode, artifacts, access) {
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
     mode,
     artifacts: resolve(artifacts),
     access,
+    plan: [],
     created: [],
     skipped: [],
     failed: [],
@@ -204,6 +323,29 @@ function saveState(path, state) {
   writeFileSync(path, `${JSON.stringify(state, null, 2)}\n`, 'utf8')
 }
 
+/**
+ * The registry decision for every package, in publish order.
+ *
+ * Delegated whole to `publish-plan.mjs` so this path and the workflow's path
+ * cannot drift into two policies. A single refusal fails everything before the
+ * first upload: an npm version can never be replaced, so a set that disagrees
+ * with the registry is a decision for a person and not a thing to work around.
+ */
+function planRegistry(artifacts) {
+  const plan = buildPlan({ artifacts })
+  if (!plan.ok) {
+    const refusals = plan.entries
+      .filter(entry => entry.action === 'refuse')
+      .map(entry => `  ${entry.name}: ${entry.reason}`)
+      .join('\n')
+    throw new Error(
+      `the registry plan refuses this set:\n${refusals}\n\n`
+      + 'A published version can never be replaced. The recovery is a new version, '
+      + 'not a retry. See docs/releasing.md.')
+  }
+  return plan
+}
+
 async function main() {
   const artifacts = resolve(option('artifacts', join(ROOT, '.release-artifacts')))
   const statePath = resolve(option('state', join(artifacts, 'first-publish-state.json')))
@@ -213,37 +355,76 @@ async function main() {
 
   gitClean()
   const verified = verifyArtifacts(artifacts)
-  const access = wantsAccess ? checkAccess() : { identity: 'not_checked', organisation: '@deepwatch', access: 'not_checked' }
+  const access = wantsAccess
+    ? checkAccess()
+    : { identity: 'not_checked', organisation: '@deepwatch', role: 'not_checked' }
   const state = initialState(publishing ? 'publish' : 'dry-run', artifacts, access)
   saveState(statePath, state)
 
   if (!publishing) {
     process.stdout.write(`first-publish dry-run: verified ${String(verified.length)} public tarballs\n`)
+    if (wantsAccess) {
+      process.stdout.write(
+        `npm identity: ${access.identity}; role in ${access.organisation}: ${access.role}; `
+        + `scope listing: ${access.scopeListing}\n`
+        + 'Publish permission is settled by npm at the first upload, not by these probes.\n')
+    }
     process.stdout.write('No registry write was attempted. Add --check-access for read-only npm access checks.\n')
     return 0
   }
   if (!confirmed) throw new Error('--publish also requires --confirm-first-publish')
 
+  // Asked once, before the first upload, and recorded. Between planning and
+  // publishing sits nothing but this loop, so re-asking per package would only
+  // add twenty round trips and twenty more chances to misread an outage.
+  const plan = planRegistry(artifacts)
+  state.plan = plan.entries.map(entry => ({
+    name: entry.name, version: entry.version, action: entry.action, reason: entry.reason,
+  }))
+  saveState(statePath, state)
+
+  const decision = new Map(plan.entries.map(entry => [entry.name, entry]))
   for (const item of verified) {
-    const present = npm(['view', `${item.name}@${item.version}`, 'version', '--json'])
-    if (present.code === 0) {
-      state.skipped.push({ name: item.name, version: item.version, reason: 'already_exists' })
+    const entry = decision.get(item.name)
+    if (entry === undefined) {
+      throw new Error(`${item.name} has no registry decision; refusing to guess`)
+    }
+    if (entry.action === 'skip') {
+      process.stdout.write(`skip      ${item.name} — ${entry.reason}\n`)
+      state.skipped.push({ name: item.name, version: item.version, reason: entry.reason })
       state.remaining.shift()
       saveState(statePath, state)
       continue
     }
+
+    process.stdout.write(`publish   ${item.name}@${item.version}\n`)
     const result = npm([
       'publish', join(artifacts, item.file), '--access', 'public', '--tag', distTag(item.version),
     ])
     if (result.code !== 0) {
-      state.failed.push({ name: item.name, version: item.version, category: 'publish_failed' })
+      const said = diagnostics(result)
+      state.failed.push({
+        name: item.name, version: item.version, category: 'publish_failed', npm: said,
+      })
       saveState(statePath, state)
-      throw new Error(`${item.name} failed; inspect the redacted npm console output and resume from the state report`)
+      process.stderr.write(`\nnpm refused ${item.name}@${item.version}:\n${said}\n\n`)
+      throw new Error(
+        `${item.name} failed. ${String(state.created.length)} package(s) reached the registry `
+        + `and are recorded in ${statePath}. Re-running re-plans against the registry and `
+        + 'resumes at the first package that is not already published from this exact build.')
     }
     state.created.push({ name: item.name, version: item.version })
     state.remaining.shift()
     saveState(statePath, state)
   }
+
+  process.stdout.write(
+    `\nfirst-publish: ${String(state.created.length)} published, `
+    + `${String(state.skipped.length)} already present with identical bytes\n`)
+  process.stdout.write(
+    'These uploads carry no registry provenance attestation: they were made from a '
+    + 'machine, not from the OIDC-authenticated workflow. Configure a Trusted '
+    + 'Publisher for each package now, and every later release will be attested.\n')
   return 0
 }
 

--- a/workspace/scripts/gen-package-docs.mjs
+++ b/workspace/scripts/gen-package-docs.mjs
@@ -8,9 +8,25 @@
  * `@deepwatch/dsh-library` from a dependency tree needs one paragraph telling
  * them what it is, what it is part of, and what it needs.
  *
- * Composed rather than written, from what each manifest already declares: its
- * description, its exports, its peers. Twenty hand-written pages drift, and a
- * page that drifts is worse than a short one that cannot.
+ * Composed rather than written, from three sources that each know something the
+ * others do not:
+ *
+ * - **the manifest** — description, exports, peers, engines, version;
+ * - **`src/index.ts`** — the `Config` interface a host actually reads, with the
+ *   doc comment on each field, so the configuration section cannot drift from
+ *   the code it describes;
+ * - **`docs/package-notes.json`** — the prose neither of those can carry: who
+ *   should install this, what it needs first, and where it sits.
+ *
+ * The notes file exists because the first version of this composed pages from
+ * the manifest alone, and twenty pages then said the same four things. A
+ * reader arriving at `@deepwatch/dsh-library` from a dependency tree learned
+ * that it was "Part of DeepWatch" and that they probably did not want it —
+ * which is true, and is not an answer to what it does or what it needs.
+ *
+ * Hand-editing a generated README is still wrong: the next run overwrites it
+ * and `--check` says so first. Edit `docs/package-notes.json` instead, which is
+ * the one file here a person is meant to write.
  *
  * The LICENSE is copied because npm ships whatever `LICENSE` file is beside a
  * manifest, and a package declaring `"license": "MIT"` with no text in the
@@ -29,6 +45,56 @@ import { byCodeUnit } from './lib/order.mjs'
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
 const REPO = 'https://github.com/oxbshw/watch-skill'
 const LICENSE = readFileSync(join(ROOT, '..', 'LICENSE'), 'utf8')
+
+/** The hand-written half: audience, prerequisites, example, placement. */
+const NOTES = JSON.parse(readFileSync(join(ROOT, 'docs', 'package-notes.json'), 'utf8'))
+
+/**
+ * The `Config` a host supplies, read out of the source that defines it.
+ *
+ * Parsed rather than imported: these are TypeScript sources, this script runs
+ * before and after the build, and a documentation generator that only works on
+ * a built tree is one that stops being run.
+ *
+ * Newlines are normalised first. A Windows checkout has CRLF, CI has LF, and a
+ * generator whose output depends on that produces a file that is permanently
+ * stale on one of the two.
+ *
+ * @param dir - the package directory.
+ * @returns `{ name, type, doc }` per field, in declaration order.
+ */
+function configFields(dir) {
+  const source = join(dir, 'src', 'index.ts')
+  if (!existsSync(source)) return []
+  const text = readFileSync(source, 'utf8').replace(/\r\n/g, '\n')
+  const start = text.indexOf('export interface Config {')
+  if (start < 0) return []
+  const end = text.indexOf('\n}', start)
+  if (end < 0) return []
+  const body = text.slice(start + 'export interface Config {'.length, end)
+
+  const fields = []
+  // One doc comment (optional) followed by one `readonly name: type`. The
+  // comment is collapsed to its first sentence: a package page is a summary,
+  // and the twelve-line explanations in these files belong in the source.
+  const shape = /(?:\/\*\*([\s\S]*?)\*\/\s*)?readonly\s+([A-Za-z0-9_]+)(\??):\s*([^\n]+?)\s*$/gm
+  for (const match of body.matchAll(shape)) {
+    const doc = (match[1] ?? '')
+      .split('\n')
+      .map(line => line.replace(/^\s*\*ered?\s?/, '').replace(/^\s*\*\s?/, '').trim())
+      .filter(line => line !== '')
+      .join(' ')
+      .trim()
+    const sentence = /^(.*?[.!?])(\s|$)/.exec(doc)
+    fields.push({
+      name: match[2],
+      optional: match[3] === '?',
+      type: match[4].replace(/,$/, '').trim(),
+      doc: sentence === null ? doc : sentence[1],
+    })
+  }
+  return fields
+}
 
 /**
  * Whether anything under the `@deepwatch` scope is on the registry.
@@ -106,16 +172,28 @@ function publishable() {
   return found.sort((a, b) => byCodeUnit(a.manifest.name, b.manifest.name))
 }
 
-/** The page for one package, from what its manifest already says. */
-function page(manifest) {
+/** The page for one package, from its manifest, its Config and its notes. */
+function page(manifest, dir) {
+  const note = NOTES.packages?.[manifest.name] ?? {}
+  const role = note.role ?? 'shared'
   const lines = [`# ${manifest.name}`, '', manifest.description, '']
 
   lines.push(
-    'Part of **DeepWatch** — the Web and Desktop agent product built on the',
-    'official [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)',
-    `packages and powered by [Watch Skill](${REPO}) for perception, evidence,`,
-    'memory and independent verification.',
+    'Part of **DeepWatch** — the agent workspace built on the official',
+    '[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)',
+    `and powered by [Watch Skill](${REPO}) for perception, evidence, memory and`,
+    'independent verification.',
     '')
+
+  // The first question a reader has, answered before anything else: is this a
+  // thing I install, or a thing that arrived in my tree? Twenty pages that all
+  // open with "Part of DeepWatch" answer it for none of them.
+  const label = NOTES.roles?.[role]
+  if (label !== undefined) {
+    lines.push(`> **${label}.**`, ...(note.audience === undefined ? [] : [`> ${note.audience}`]), '')
+  } else if (note.audience !== undefined) {
+    lines.push(`> ${note.audience}`, '')
+  }
 
   const subpaths = Object.keys(manifest.exports ?? {})
     .filter(entry => entry !== './package.json')
@@ -132,8 +210,8 @@ function page(manifest) {
     const optional = manifest.peerDependenciesMeta ?? {}
     lines.push('## Peers', '', 'Provided by the host rather than installed here:', '')
     for (const [name, declared] of peers.sort(([a], [b]) => byCodeUnit(a, b))) {
-      const note = optional[name]?.optional === true ? ' — optional' : ''
-      lines.push(`- \`${name}@${range(name, declared)}\`${note}`)
+      const marker = optional[name]?.optional === true ? ' — optional' : ''
+      lines.push(`- \`${name}@${range(name, declared)}\`${marker}`)
     }
     lines.push('')
   }
@@ -155,7 +233,7 @@ function page(manifest) {
       '')
   }
   lines.push('```sh', `npm install ${manifest.name}`, '```', '')
-  if (manifest.name !== BUNDLE) {
+  if (role !== 'product') {
     lines.push(
       `Rarely on its own. [\`${BUNDLE}\`](${REPO}/tree/main/workspace/packages/watch/bundle#readme)`,
       'composes this package with the rest of DeepWatch and is what a profile',
@@ -164,13 +242,41 @@ function page(manifest) {
       '')
   }
 
+  if (note.example !== undefined) {
+    lines.push('## Example', '')
+    if (note.example.caption !== undefined) lines.push(note.example.caption, '')
+    lines.push(`\`\`\`${note.example.lang ?? 'sh'}`, note.example.code, '```', '')
+  }
+
+  // Read out of the `Config` interface rather than restated beside it. The
+  // defaults live in the schema and the prose lives in the doc comments, so a
+  // field added to the code appears here on the next run and a field removed
+  // stops appearing.
+  const fields = configFields(dir)
+  if (fields.length > 0) {
+    lines.push(
+      '## Configuration',
+      '',
+      'Supplied by the host when it mounts this plugin.',
+      '',
+      '| Option | Type | |',
+      '| --- | --- | --- |')
+    for (const field of fields) {
+      lines.push(`| \`${field.name}\`${field.optional ? ' *(optional)*' : ''} `
+        + `| \`${field.type}\` | ${field.doc} |`)
+    }
+    lines.push('')
+  }
+
   const node = manifest.engines?.node
-  if (node !== undefined) {
-    lines.push('## Requirements', '', `- Node \`${node}\``)
+  if (node !== undefined || note.prerequisites !== undefined) {
+    lines.push('## Requirements', '')
+    if (node !== undefined) lines.push(`- Node \`${node}\``)
     if (Object.keys(manifest.peerDependencies ?? {}).length > 0) {
       lines.push('- The peers above, supplied by the host composition')
     }
     lines.push('')
+    if (note.prerequisites !== undefined) lines.push(note.prerequisites, '')
   }
 
   // The version *is* the stability statement. Deriving the sentence from it
@@ -211,13 +317,13 @@ function page(manifest) {
       '')
   }
 
+  lines.push('## Where this fits', '')
+  if (note.fits !== undefined) lines.push(note.fits, '')
   lines.push(
-    '## Where this fits',
-    '',
-    'These packages are composed together; installing one on its own is rarely',
-    'what you want. The whole picture, the gates it has to pass, and how to run',
-    'DeepWatch is in the',
-    `[workspace README](${REPO}/tree/main/workspace#readme).`,
+    'The twenty packages and how they compose:',
+    `[the package map](${REPO}/blob/main/workspace/docs/packages.md).`,
+    'Running DeepWatch, and the gates a change has to pass:',
+    `[the workspace README](${REPO}/tree/main/workspace#readme).`,
     '',
     '## Attribution',
     '',
@@ -238,7 +344,7 @@ function main() {
 
   for (const { dir, manifest } of publishable()) {
     const files = [[join(dir, 'LICENSE'), LICENSE]]
-    if (!HAND_WRITTEN.has(manifest.name)) files.push([join(dir, 'README.md'), page(manifest)])
+    if (!HAND_WRITTEN.has(manifest.name)) files.push([join(dir, 'README.md'), page(manifest, dir)])
 
     for (const [path, content] of files) {
       const current = existsSync(path) ? readFileSync(path, 'utf8') : null

--- a/workspace/scripts/gen-package-docs.mjs
+++ b/workspace/scripts/gen-package-docs.mjs
@@ -245,6 +245,14 @@ function page(manifest, dir) {
   if (note.example !== undefined) {
     lines.push('## Example', '')
     if (note.example.caption !== undefined) lines.push(note.example.caption, '')
+    // An example that installs from the registry is an install command like
+    // any other, and it is far enough down the page that the callout above the
+    // Install block no longer counts as nearby. Repeated rather than moved:
+    // the reader who scrolled to a worked example is exactly the one who will
+    // paste it without scrolling back up.
+    if (registryStatus() === 'unpublished' && note.example.code.includes('@deepwatch/')) {
+      lines.push(`> Pending the \`${firstPublicationTag()}\` release — see Install above.`, '')
+    }
     lines.push(`\`\`\`${note.example.lang ?? 'sh'}`, note.example.code, '```', '')
   }
 

--- a/workspace/scripts/gen-release-notes.mjs
+++ b/workspace/scripts/gen-release-notes.mjs
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+/**
+ * The body of the DeepWatch GitHub Release, composed from what was sealed.
+ *
+ * This train had no Release at all: the tag published twenty packages to npm
+ * and then stopped. That left two things missing. The obvious one is a page to
+ * link to. The one that mattered more is a download — somebody who already
+ * runs a DeepSeek Harness wants `@deepwatch/dsh-bundle`, and an air-gapped or
+ * registry-restricted install of it needs the tarball as a file, not as a
+ * registry coordinate.
+ *
+ * Composed rather than written, for the same reason the package pages are.
+ * Release notes typed by hand describe the release the author remembered; these
+ * describe the set that was actually sealed, because every number in them is
+ * read out of `packed-artifacts.json` and the provenance manifest beside it. If
+ * the pack changes, the notes change with it.
+ *
+ * Usage:
+ *   node scripts/gen-release-notes.mjs --artifacts <dir> --manifest <file>
+ *     [--out <file>]
+ *
+ * @module scripts/gen-release-notes
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+import { byCodeUnit } from './lib/order.mjs'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+const REPO = 'https://github.com/oxbshw/watch-skill'
+const BUNDLE = '@deepwatch/dsh-bundle'
+const CLI = '@deepwatch/cli'
+
+/** A tarball name as the Release attaches it, from the npm package name. */
+function assetName(name, version) {
+  return `${name.replace('@', '').replace('/', '-')}-${version}.tgz`
+}
+
+/** Bytes, at the precision a download decision needs. */
+function human(bytes) {
+  if (bytes < 1024) return `${String(bytes)} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} kB`
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`
+}
+
+/**
+ * The notes.
+ *
+ * @param inventory - parsed `packed-artifacts.json`.
+ * @param manifest - parsed provenance manifest.
+ * @returns markdown.
+ */
+export function notes(inventory, manifest) {
+  const packages = [...inventory.packages].sort((a, b) => byCodeUnit(a.name, b.name))
+  const version = packages[0]?.version ?? 'unknown'
+  const cli = packages.find(entry => entry.name === CLI)
+  const bundle = packages.find(entry => entry.name === BUNDLE)
+  const stable = !version.includes('-')
+
+  const out = []
+  const say = (...lines) => { out.push(...lines) }
+
+  say(
+    `**DeepWatch ${version}** — the agent workspace built on the official`,
+    '[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) and',
+    `powered by [Watch Skill](${REPO}) for perception, evidence and independent`,
+    'verification.',
+    '',
+    'An agent works inside something that watches it: every tool call leaves a',
+    'receipt, every path a tool declares is checked against one workspace',
+    'boundary, and *did that actually work?* is answered by Watch Core running a',
+    'frozen contract rather than by the model that did the work.',
+    '')
+
+  say('## Install', '')
+  say('**The whole workspace**', '', '```bash', `npm install -g ${CLI}`,
+    'deepwatch setup', 'deepwatch web --workspace ./my-project', '```', '')
+  say('Or without installing anything:', '', '```bash',
+    `npx ${CLI}@${version} doctor`, '```', '')
+  say('**Into a DeepSeek Harness you already run**', '', '```bash',
+    `dsh plugin --profile web add ${BUNDLE}`, '```', '')
+
+  if (bundle !== undefined) {
+    say(
+      'That is the supported contract: the package declares `dsh.bundle.patch`,',
+      "so DSH reconciles it into the profile's layer stack and applies the",
+      "patch after its own layers. There is no separate `.dsh` archive format —",
+      'the distribution *is* the npm tarball, and it is attached here so a',
+      'registry-restricted or offline install can use the file directly:',
+      '',
+      '```bash',
+      `dsh plugin --profile web add ./${bundle.file}`,
+      '```',
+      '')
+  }
+
+  say(
+    'Watch Core is the engine and installs separately, from PyPI:',
+    '',
+    '```bash',
+    "pip install 'watch-skill[standard]'",
+    '```',
+    '',
+    'The Bridge finds the executable on `PATH` and connects on its own.',
+    '')
+
+  say('## What is in this release', '')
+  say(
+    `${String(packages.length)} packages, published together and in dependency`,
+    'order so every version resolves the moment it is public. Two of them are',
+    'installed deliberately; the rest are what those two compose.',
+    '')
+  say('| Package | Size | SHA-256 |', '| --- | --- | --- |')
+  for (const entry of packages) {
+    const lead = entry.name === CLI || entry.name === BUNDLE ? '**' : ''
+    say(`| ${lead}\`${entry.name}\`${lead} | ${human(entry.bytes)} `
+      + `| \`${entry.sha256.slice(0, 16)}…\` |`)
+  }
+  say('')
+  if (cli !== undefined) {
+    say(
+      `\`${CLI}\` is the command-line product and \`${BUNDLE}\` is the`,
+      'integration; the other eighteen are internal dependencies of those two',
+      'and are published because a dependency that is not on the registry is a',
+      'package that does not install.',
+      '')
+  }
+
+  say('## Provenance', '')
+  say('| | |', '| --- | --- |')
+  say(`| Source commit | \`${manifest.source?.commit ?? 'unknown'}\` |`)
+  say(`| Source tree | \`${manifest.source?.tree ?? 'unknown'}\` |`)
+  say(`| Worktree | ${manifest.source?.clean === true ? 'clean' : '**dirty**'} |`)
+  say(`| Pinned Harness | \`${manifest.harness?.package ?? '?'}@${manifest.harness?.version ?? '?'}\` |`)
+  say(`| Built with | Node ${manifest.toolchain?.node ?? '?'}, `
+    + `${manifest.toolchain?.pnpm ?? '?'} |`)
+  say('')
+  say(
+    'Every asset here is covered by `SHA256SUMS`, and',
+    '`.release-artifacts-provenance.json` binds those digests to the commit and',
+    'tree above. Check a download before trusting it:',
+    '',
+    '```bash',
+    'sha256sum -c SHA256SUMS',
+    '```',
+    '')
+  say(
+    'The packages on npm carry registry provenance only where the release',
+    'workflow published them over OIDC; the attached tarballs are the same bytes',
+    'either way, which is what `SHA256SUMS` lets you confirm for yourself.',
+    '')
+
+  say('## Documentation', '')
+  say(
+    `- [Getting started](${REPO}/blob/main/workspace/docs/getting-started.md)`,
+    `- [Install and upgrade](${REPO}/blob/main/workspace/docs/install-and-upgrade.md)`,
+    `- [Configuration](${REPO}/blob/main/workspace/docs/configuration.md)`,
+    `- [Verification](${REPO}/blob/main/docs/verification.md)`,
+    `- [Troubleshooting](${REPO}/blob/main/workspace/docs/troubleshooting.md)`,
+    `- [Known limitations](${REPO}/blob/main/workspace/docs/known-limitations.md)`,
+    '')
+
+  if (!stable) {
+    say(
+      '> **Prerelease.** This version does not take the `latest` dist-tag; ask',
+      '> for it by name.',
+      '')
+  }
+
+  say('---', '',
+    'Built on DeepSeek Harness · Powered by Watch Skill. An independent project,',
+    'not affiliated with or endorsed by DeepSeek.',
+    '')
+
+  return `${out.join('\n')}\n`
+}
+
+function main(argv) {
+  const flag = (name, fallback = null) => {
+    const at = argv.indexOf(name)
+    return at >= 0 && at + 1 < argv.length ? argv[at + 1] : fallback
+  }
+  const artifacts = flag('--artifacts', join(ROOT, '.release-artifacts'))
+  const manifestPath = flag('--manifest', join(ROOT, '.release-artifacts-provenance.json'))
+  const out = flag('--out', join(artifacts, 'release-notes.md'))
+
+  try {
+    const inventory = JSON.parse(readFileSync(join(artifacts, 'packed-artifacts.json'), 'utf8'))
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'))
+    writeFileSync(out, notes(inventory, manifest), 'utf8')
+  } catch (cause) {
+    process.stderr.write(
+      `gen-release-notes: ${cause instanceof Error ? cause.message : String(cause)}\n`)
+    return 1
+  }
+  process.stdout.write(`release notes: ${out}\n`)
+  return 0
+}
+
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.exitCode = main(process.argv.slice(2))
+}
+
+export { assetName, human }

--- a/workspace/scripts/qa-journey-live.mjs
+++ b/workspace/scripts/qa-journey-live.mjs
@@ -1,0 +1,376 @@
+#!/usr/bin/env node
+/**
+ * The user journey, driven by an actual model.
+ *
+ * This is the other half of the acceptance pair, and the half that cannot be
+ * faked. `qa-acceptance-local.mjs` proves the installed product runs and that
+ * Core decides verdicts; `qa-acceptance-agent.mjs` proves the Host, the ledger
+ * and the Library behave, and it does that against a **loopback stub this
+ * repository owns** — deterministic infrastructure, disclosed as such, whose
+ * tool calls are a script this repository wrote.
+ *
+ * A scripted provider is the right tool for those questions and the wrong
+ * evidence for this one. It cannot answer *will a model, given an ordinary
+ * instruction that names no Watch tool, choose the right tools and produce the
+ * right work* — because the script already chose. So nothing here is scripted:
+ * every tool call below is the model's, and the assertions read what actually
+ * landed on disk and in the ledger.
+ *
+ * **This refuses to run against a loopback provider.** The first assertion is
+ * that the configured base URL is not a local address, and it is first because
+ * a pass produced against a stub and labelled "real model" is worse than no
+ * pass at all.
+ *
+ * **The credential is never read by this file.** The route names a credential
+ * *reference*; `dsh-credentials-local` resolves it from the document the
+ * profile is pointed at. Nothing here calls `credentials.set`, so nothing here
+ * can write into somebody's credential store.
+ *
+ * **Bounded, because a model can be asked to do anything.** A wall-clock
+ * budget, a turn ceiling and a per-turn deadline, all reported in the output,
+ * so the cost of the run is a number rather than a hope.
+ *
+ * Usage:
+ *   node scripts/qa-journey-live.mjs --url http://127.0.0.1:8877 \
+ *     --home <DSH_HOME> --workspace <dir> \
+ *     --provider openrouter --model deepseek/deepseek-v4-pro \
+ *     --base-url https://openrouter.ai/api/v1 --credential-ref OPENROUTER_API_KEY \
+ *     [--budget-ms 1800000] [--max-turns 12] [--out report.json]
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+function flag(name, fallback = null) {
+  const at = process.argv.indexOf(`--${name}`)
+  if (at === -1) return fallback
+  const value = process.argv[at + 1]
+  if (value === undefined || value.startsWith('--')) {
+    process.stderr.write(`qa-journey-live: --${name} needs a value\n`)
+    process.exit(2)
+  }
+  return value
+}
+
+const URL_BASE = flag('url', 'http://127.0.0.1:8877')
+const HOME = flag('home')
+const WORKSPACE = flag('workspace')
+const PROVIDER = flag('provider', 'openrouter')
+const MODEL = flag('model')
+const BASE_URL = flag('base-url', 'https://openrouter.ai/api/v1')
+const CREDENTIAL_REF = flag('credential-ref', 'OPENROUTER_API_KEY')
+const PROFILE = flag('profile', 'deepwatch')
+const BUDGET_MS = Number(flag('budget-ms', '1800000'))
+const MAX_TURNS = Number(flag('max-turns', '12'))
+const TURN_MS = Number(flag('turn-timeout-ms', '300000'))
+const OUT = flag('out', join(dirname(fileURLToPath(import.meta.url)), '..', 'qa', 'journey-live.json'))
+
+if (HOME === null || WORKSPACE === null || MODEL === null) {
+  process.stderr.write('qa-journey-live: --home, --workspace and --model are required\n')
+  process.exit(2)
+}
+
+const started = Date.now()
+let turnsTaken = 0
+
+const claims = []
+const claim = (id, ok, detail) => {
+  claims.push({ id, ok, detail })
+  process.stdout.write(
+    `${ok ? 'PASS' : 'FAIL'} ${id} :: ${JSON.stringify(detail).slice(0, 500)}\n`)
+  return ok
+}
+
+async function rpc(method, payload) {
+  const response = await fetch(`${URL_BASE}/api/${method}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      type: 'client-request',
+      rpcId: `lj-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`,
+      method, payload,
+    }),
+  })
+  const text = await response.text()
+  let body = null
+  try { body = JSON.parse(text) } catch { body = { raw: text.slice(0, 300) } }
+  return { http: response.status, result: body?.result ?? null }
+}
+
+const search = async (query) => {
+  const answer = await rpc('watchQuery/librarySearch', { args: { request: {
+    protocol: 1, requestId: `lib-${Date.now().toString(36)}`, query,
+    modalities: [], limit: 60, cursor: null, deadlineMs: 30_000,
+  } } })
+  return answer.result?.value ?? {}
+}
+
+const open = async (recordId) => {
+  const answer = await rpc('watchQuery/libraryGet', { args: { request: {
+    protocol: 1, requestId: `g-${Date.now().toString(36)}`, recordId, deadlineMs: 30_000,
+  } } })
+  return answer.result?.value ?? {}
+}
+
+const receiptsFor = async (sessionId, query) => {
+  const found = await search(query)
+  return (found.records ?? []).filter(record =>
+    (record.tags ?? []).includes('execution-receipt') && record.runId === sessionId)
+}
+
+const wait = (ms) => new Promise((done) => { setTimeout(done, ms) })
+
+/** Whether a base URL points at this machine. */
+export function isLoopback(url) {
+  try {
+    const { hostname } = new URL(url)
+    return hostname === 'localhost' || hostname === '::1'
+      || /^127\./.test(hostname) || /^0\.0\.0\.0$/.test(hostname)
+      || hostname.endsWith('.localhost')
+  } catch { return true }
+}
+
+/**
+ * Run one turn and wait for it to settle.
+ *
+ * There is no stub to witness the request here, so the only signal is the
+ * session row. `session.prompt` returns before the loop marks the session
+ * running, so a poll that breaks on the first `running: false` reads the moment
+ * *before* the turn.
+ */
+async function turn(sessionId, text, { timeoutMs = TURN_MS } = {}) {
+  if (turnsTaken >= MAX_TURNS) {
+    return { settled: false, sawRunning: false, reason: 'turn ceiling reached' }
+  }
+  if (Date.now() - started > BUDGET_MS) {
+    return { settled: false, sawRunning: false, reason: 'wall-clock budget spent' }
+  }
+  turnsTaken += 1
+  await rpc('session.prompt', { sessionId, mode: 'queue', content: [{ type: 'text', text }] })
+
+  const deadline = Date.now() + timeoutMs
+  let sawRunning = false
+  while (Date.now() < deadline) {
+    const listed = await rpc('session.list', {})
+    const row = listed.result?.value?.items?.find(item => item.sessionId === sessionId) ?? null
+    if (row?.running === true) sawRunning = true
+    if (sawRunning && row?.running === false) {
+      await wait(2_000)
+      return { settled: true, sawRunning, reason: null }
+    }
+    await wait(750)
+  }
+  return { settled: false, sawRunning, reason: 'turn deadline' }
+}
+
+const work = join(WORKSPACE, 'work')
+const repo = join(work, 'owner-test')
+mkdirSync(repo, { recursive: true })
+const totalsPath = join(repo, 'totals.json')
+const TOTALS = '{"items":[12,18,30],"total":60}'
+
+const notes = { provider: PROVIDER, model: MODEL, baseURL: BASE_URL }
+let sessionId = null
+
+// ── 0. this is a hosted provider, and the run says so before anything else ───
+claim('LJ-00 the route is a hosted provider, not a loopback stub',
+  !isLoopback(BASE_URL), { baseURL: BASE_URL, provider: PROVIDER, model: MODEL })
+if (isLoopback(BASE_URL)) {
+  process.stderr.write(
+    'qa-journey-live: refusing to run. This pass exists to exercise an actual '
+    + 'model, and the configured base URL is local. A run against a loopback '
+    + 'provider is qa-acceptance-agent.mjs, and it says so in its own output.\n')
+  process.exit(2)
+}
+
+// ── 1. configure the route; the credential stays where it already is ─────────
+const routed = await rpc('settings.replace', {
+  ns: 'llm-pi-ai',
+  section: { providers: { [PROVIDER]: {
+    displayName: PROVIDER, apiKeyEnv: CREDENTIAL_REF,
+    api: 'openai-completions', baseURL: BASE_URL,
+    models: [{ id: MODEL, name: MODEL, contextWindow: 131072 }],
+  } } },
+})
+claim('LJ-01 the provider settings were accepted', routed.result?.ok !== false,
+  { error: routed.result?.error ?? null })
+
+let proved = null
+for (let attempt = 1; attempt <= 4; attempt += 1) {
+  const tested = await rpc('watchQuery/providerTest', { args: { request: {
+    protocol: 1, requestId: `route-${String(attempt)}`, deadlineMs: 60_000,
+    provider: PROVIDER, model: MODEL,
+  } } })
+  proved = { attempt, ok: tested.result?.value?.ok === true,
+    message: tested.result?.value?.message ?? tested.result?.error?.message ?? null }
+  if (proved.ok) break
+  await wait(2_000)
+}
+// A bounded, real request to the hosted endpoint. This is the first thing in
+// the run that costs money, and it is also the only proof that the credential
+// resolves without this file ever seeing it.
+claim('LJ-02 a real model request reached the provider and came back', proved?.ok === true,
+  proved ?? { ok: false })
+
+if (proved?.ok === true) {
+  await rpc('settings.replace', {
+    ns: 'watch-bindings',
+    section: { version: 1, roles: { agent_model: {
+      provider: PROVIDER, model: MODEL, credentialRef: CREDENTIAL_REF,
+      boundAt: new Date().toISOString(),
+    } } },
+  })
+  await rpc('settings.replace', {
+    ns: 'agent-default-model', section: { provider: PROVIDER, model: MODEL } })
+
+  const created = await rpc('session.create', { cwd: work })
+  sessionId = created.result?.value?.sessionId ?? null
+  claim('LJ-03 a session opens on the workspace', sessionId !== null, { sessionId, cwd: 'work' })
+}
+
+if (sessionId !== null) {
+  // ── 2. ordinary work. No Watch tool is named. ──────────────────────────────
+  const first = await turn(sessionId,
+    'In this workspace, create a file at owner-test/totals.json whose contents are '
+    + 'exactly {"items":[12,18,30],"total":60} — the total is the sum of the items. '
+    + 'Then tell me what the file contains.')
+  claim('LJ-04 the first turn ran and settled', first.settled, first)
+
+  const onDisk = existsSync(totalsPath) ? readFileSync(totalsPath, 'utf8').trim() : null
+  claim('LJ-05 the model created the file the task asked for',
+    onDisk !== null && JSON.stringify(JSON.parse(onDisk ?? 'null')) === TOTALS,
+    { path: 'owner-test/totals.json', content: onDisk })
+
+  await wait(2_500)
+  const writes = await receiptsFor(sessionId, 'write')
+  // The model chose the tool. Nothing here scripted a call, so a receipt is
+  // evidence that tools were offered *and* taken -- which a completion body
+  // carrying a tool list is not.
+  claim('LJ-06 the model chose a tool, and Watch recorded the call unasked',
+    writes.length >= 1,
+    { receipts: writes.length, tags: writes.map(record => record.tags) })
+
+  // ── 3. ask for proof, and let the model pick the verification tool ────────
+  await turn(sessionId,
+    'Prove that owner-test/totals.json really holds a total of 60, using a check '
+    + 'that something other than you evaluates. Report the verdict you get back.')
+
+  await wait(2_500)
+  let proofs = await receiptsFor(sessionId, 'watch_verify')
+  claim('LJ-07 the model reached for independent verification on its own',
+    proofs.length >= 1,
+    { verifications: proofs.length, verdicts: proofs.map(record => record.verdict) })
+  claim('LJ-08 the first verdict is VERIFIED, and it is Core’s',
+    proofs.some(record => record.verdict === 'VERIFIED'),
+    { verdicts: proofs.map(record => record.verdict) })
+
+  // ── 4. a controlled mismatch ───────────────────────────────────────────────
+  await turn(sessionId,
+    'Now change owner-test/totals.json so the items are [12,18,28] and the total '
+    + 'field still says 60, then run the same check again and tell me the verdict.')
+  await wait(2_500)
+  proofs = await receiptsFor(sessionId, 'watch_verify')
+  const failed = proofs.filter(record => record.verdict === 'FAILED')
+  claim('LJ-09 the mismatch fails, rather than being reported as fine',
+    failed.length >= 1,
+    { verdicts: proofs.map(record => record.verdict) })
+
+  // ── 5. the correction ──────────────────────────────────────────────────────
+  await turn(sessionId,
+    'Put owner-test/totals.json back to items [12,18,30] with a total of 60, and '
+    + 'run the check once more.')
+  await wait(2_500)
+  proofs = await receiptsFor(sessionId, 'watch_verify')
+  const passes = proofs.filter(record => record.verdict === 'VERIFIED')
+  claim('LJ-10 the correction passes again',
+    passes.length >= 2 && failed.length >= 1,
+    { verdicts: proofs.map(record => record.verdict) })
+
+  // ── 6. distinct Core identities, in the rows Compare renders ──────────────
+  const identities = [...new Set(proofs.flatMap(record => record.evidenceIds ?? []))]
+  claim('LJ-11 each verification has its own Core identity',
+    identities.length >= 3 && identities.every(id => String(id).startsWith('ver_')),
+    { identities })
+
+  const opened = []
+  for (const record of proofs) opened.push(await open(record.recordId))
+  const revisions = [...new Set(opened.map(entry => entry.record?.revisionId).filter(Boolean))]
+  claim('LJ-12 the Library opens each one carrying the verdict Compare reads',
+    opened.filter(entry => entry.outcome === 'record').length === proofs.length
+      && revisions.length === proofs.length,
+    { opened: opened.map(entry => ({
+      outcome: entry.outcome ?? null, verdict: entry.record?.verdict ?? null })),
+    revisions: revisions.length })
+
+  // ── 7. perception ─────────────────────────────────────────────────────────
+  const before = turnsTaken
+  const perception = await turn(sessionId,
+    'Look at what has been indexed and tell me what sources are available to you, '
+    + 'citing anything you find by its timestamp.')
+  const perceptionCalls = await receiptsFor(sessionId, 'watch_search_sources')
+  claim('LJ-13 a perception request reached Core through a tool the model chose',
+    perception.settled && perceptionCalls.length >= 1,
+    { settled: perception.settled, calls: perceptionCalls.length, turnsUsed: turnsTaken - before })
+
+  // ── 8. a bounded delegated task ────────────────────────────────────────────
+  const delegated = await turn(sessionId,
+    'Delegate this to a sub-task and report back in one sentence: count how many '
+    + 'JSON files are under owner-test and name them.')
+  const subagent = await receiptsFor(sessionId, 'task')
+  claim('LJ-14 a delegated task ran within the budget',
+    delegated.settled,
+    { settled: delegated.settled, reason: delegated.reason, subagentReceipts: subagent.length })
+
+  // ── 9. stopping a running task ─────────────────────────────────────────────
+  await rpc('session.prompt', { sessionId, mode: 'queue', content: [{ type: 'text',
+    text: 'Write a very long, detailed description of every file in this workspace, '
+      + 'one paragraph per file, and keep going until you have covered everything.' }] })
+  turnsTaken += 1
+  let running = false
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    const listed = await rpc('session.list', {})
+    const row = listed.result?.value?.items?.find(item => item.sessionId === sessionId) ?? null
+    if (row?.running === true) { running = true; break }
+    await wait(500)
+  }
+  const cancelled = await rpc('session.cancel', { sessionId })
+  let stopped = false
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    const listed = await rpc('session.list', {})
+    const row = listed.result?.value?.items?.find(item => item.sessionId === sessionId) ?? null
+    if (row?.running === false) { stopped = true; break }
+    await wait(500)
+  }
+  claim('LJ-15 a running task can be stopped, and stops',
+    running && stopped,
+    { sawRunning: running, stopped, http: cancelled.http })
+}
+
+const elapsed = Date.now() - started
+claim('LJ-16 the run stayed inside its declared budget',
+  elapsed <= BUDGET_MS && turnsTaken <= MAX_TURNS,
+  { elapsedMs: elapsed, budgetMs: BUDGET_MS, turns: turnsTaken, maxTurns: MAX_TURNS })
+
+const report = {
+  experience: 'B — an actual model, not a scripted provider',
+  provider: notes,
+  loopback: isLoopback(BASE_URL),
+  profile: PROFILE,
+  sessionId,
+  budget: { elapsedMs: elapsed, budgetMs: BUDGET_MS, turns: turnsTaken, maxTurns: MAX_TURNS },
+  claims,
+  passed: claims.filter(entry => entry.ok).length,
+  failed: claims.filter(entry => !entry.ok).length,
+}
+mkdirSync(dirname(OUT), { recursive: true })
+writeFileSync(OUT, `${JSON.stringify(report, null, 2)}\n`, 'utf8')
+process.stdout.write(`\nreport: ${OUT}\n`)
+
+const failing = claims.filter(entry => !entry.ok)
+if (failing.length > 0) {
+  process.stderr.write(
+    `qa-journey-live: ${String(failing.length)} claim(s) failed: `
+    + `${failing.map(entry => entry.id).join(', ')}\n`)
+  process.exitCode = 1
+}

--- a/workspace/scripts/qa-journey-live.mjs
+++ b/workspace/scripts/qa-journey-live.mjs
@@ -64,10 +64,16 @@ const PROFILE = flag('profile', 'deepwatch')
 const BUDGET_MS = Number(flag('budget-ms', '1800000'))
 const MAX_TURNS = Number(flag('max-turns', '12'))
 const TURN_MS = Number(flag('turn-timeout-ms', '300000'))
+const RECEIPTS = flag('receipts', null)
 const OUT = flag('out', join(dirname(fileURLToPath(import.meta.url)), '..', 'qa', 'journey-live.json'))
 
-if (HOME === null || WORKSPACE === null || MODEL === null) {
-  process.stderr.write('qa-journey-live: --home, --workspace and --model are required\n')
+if (HOME === null || WORKSPACE === null || MODEL === null || RECEIPTS === null) {
+  process.stderr.write(
+    'qa-journey-live: --home, --workspace, --model and --receipts are required.\n'
+    + '`--receipts` is the journal directory the profile writes to, normally\n'
+    + '<workspace>/.watch/receipts. Which tools a model chose is read from there\n'
+    + 'rather than from a text search, because a search answers a different\n'
+    + 'question and answers it wrongly.\n')
   process.exit(2)
 }
 
@@ -117,6 +123,37 @@ const receiptsFor = async (sessionId, query) => {
   const found = await search(query)
   return (found.records ?? []).filter(record =>
     (record.tags ?? []).includes('execution-receipt') && record.runId === sessionId)
+}
+
+/**
+ * Every receipt this run produced, read from the journal rather than searched.
+ *
+ * The Library's search is the surface a person uses and it is the right thing
+ * to assert *about*. It is the wrong thing to establish *which tools the model
+ * chose*: a text query matches indexed content, so "did it call `write`"
+ * becomes "does the word write retrieve anything", and the first version of
+ * this file reported that a model which had called `write` four times had
+ * called it none. The journal is the Host's own append-only record of its own
+ * dispatches, and it answers the question that was actually being asked.
+ */
+function journalled(receiptsDir) {
+  const file = join(receiptsDir, 'receipts.jsonl')
+  if (!existsSync(file)) return []
+  return readFileSync(file, 'utf8')
+    .split('\n')
+    .filter(line => line.trim() !== '')
+    .flatMap((line) => { try { return [JSON.parse(line)] } catch { return [] } })
+}
+
+/** The tool each journalled receipt names. */
+function toolsIn(records) {
+  const counts = {}
+  for (const record of records) {
+    const tag = (record.tags ?? []).find(entry => entry.startsWith('tool:'))
+    if (tag === undefined) continue
+    counts[tag.slice('tool:'.length)] = (counts[tag.slice('tool:'.length)] ?? 0) + 1
+  }
+  return counts
 }
 
 const wait = (ms) => new Promise((done) => { setTimeout(done, ms) })
@@ -243,13 +280,13 @@ if (sessionId !== null) {
     { path: 'owner-test/totals.json', content: onDisk })
 
   await wait(2_500)
-  const writes = await receiptsFor(sessionId, 'write')
   // The model chose the tool. Nothing here scripted a call, so a receipt is
   // evidence that tools were offered *and* taken -- which a completion body
   // carrying a tool list is not.
-  claim('LJ-06 the model chose a tool, and Watch recorded the call unasked',
-    writes.length >= 1,
-    { receipts: writes.length, tags: writes.map(record => record.tags) })
+  const chosen = toolsIn(journalled(RECEIPTS))
+  claim('LJ-06 the model chose tools nobody scripted, and Watch recorded them',
+    (chosen.write ?? 0) >= 1,
+    { tools: chosen })
 
   // ── 3. ask for proof, and let the model pick the verification tool ────────
   await turn(sessionId,
@@ -261,31 +298,58 @@ if (sessionId !== null) {
   claim('LJ-07 the model reached for independent verification on its own',
     proofs.length >= 1,
     { verifications: proofs.length, verdicts: proofs.map(record => record.verdict) })
-  claim('LJ-08 the first verdict is VERIFIED, and it is Core’s',
-    proofs.some(record => record.verdict === 'VERIFIED'),
-    { verdicts: proofs.map(record => record.verdict) })
+  // Not "the first verdict is VERIFIED". That asserts an ordering the model
+  // controls, and one run failed it for the best reason in this whole file:
+  // the model composed a contract that included a `file_digest` check and
+  // supplied a sha256 it had made up. Three checks passed, the invented one
+  // did not, and Core returned FAILED — which is the product doing exactly
+  // what it exists to do. A gate that called that a regression would be
+  // teaching somebody to make Core agree with the model.
+  //
+  // What must hold is that every verdict is Core's, carrying Core's identity
+  // and Core's reason.
+  claim('LJ-08 every verdict carries Core’s identity and Core’s reason',
+    proofs.length >= 1
+      && proofs.every(record => (record.evidenceIds ?? []).some(
+        id => String(id).startsWith('ver_'))),
+    { verdicts: proofs.map(record => record.verdict),
+      identities: proofs.flatMap(record => record.evidenceIds ?? []) })
 
   // ── 4. a controlled mismatch ───────────────────────────────────────────────
+  //
+  // The break has to be one the claim under test can see. The first version of
+  // this asked for items `[12,18,28]` with the total left at 60 and then asked
+  // for "the same check" -- and the model, which composes its own contract,
+  // had written one that checks the `total` field. Sixty was still sixty, the
+  // contract passed, and the run recorded a mismatch that was not one. What is
+  // broken now is the number the claim is *about*.
   await turn(sessionId,
-    'Now change owner-test/totals.json so the items are [12,18,28] and the total '
-    + 'field still says 60, then run the same check again and tell me the verdict.')
+    'Change the total field in owner-test/totals.json to 58, leaving the items '
+    + 'as they are. Then prove again that the file holds a total of 60, and tell '
+    + 'me the verdict you get back.')
   await wait(2_500)
   proofs = await receiptsFor(sessionId, 'watch_verify')
   const failed = proofs.filter(record => record.verdict === 'FAILED')
-  claim('LJ-09 the mismatch fails, rather than being reported as fine',
+  claim('LJ-09 the broken claim fails, rather than being reported as fine',
     failed.length >= 1,
     { verdicts: proofs.map(record => record.verdict) })
 
   // ── 5. the correction ──────────────────────────────────────────────────────
   await turn(sessionId,
-    'Put owner-test/totals.json back to items [12,18,30] with a total of 60, and '
-    + 'run the check once more.')
+    'Put the total back to 60 so it matches the items, and prove it once more.')
   await wait(2_500)
-  proofs = await receiptsFor(sessionId, 'watch_verify')
-  const passes = proofs.filter(record => record.verdict === 'VERIFIED')
-  claim('LJ-10 the correction passes again',
-    passes.length >= 2 && failed.length >= 1,
-    { verdicts: proofs.map(record => record.verdict) })
+  // Read from the journal, which is in dispatch order. The Library returns
+  // records, and "did the repair land after the break" is a question about
+  // sequence that a result set cannot answer.
+  const sequence = journalled(RECEIPTS)
+    .filter(record => (record.tags ?? []).includes('tool:watch_verify')
+      && typeof record.verdict === 'string')
+    .map(record => record.verdict)
+  const lastFailure = sequence.lastIndexOf('FAILED')
+  const lastPass = sequence.lastIndexOf('VERIFIED')
+  claim('LJ-10 the repair comes after the break, and it passes',
+    lastFailure !== -1 && lastPass > lastFailure,
+    { sequence, brokeAt: lastFailure, fixedAt: lastPass })
 
   // ── 6. distinct Core identities, in the rows Compare renders ──────────────
   const identities = [...new Set(proofs.flatMap(record => record.evidenceIds ?? []))]
@@ -304,23 +368,44 @@ if (sessionId !== null) {
     revisions: revisions.length })
 
   // ── 7. perception ─────────────────────────────────────────────────────────
+  //
+  // Which Watch tool answers this is the model's choice, and there are several
+  // right ones -- `watch_search_sources` for a query, `watch_list_sources` for
+  // an inventory. Asserting one tool name was asserting a decision the model
+  // gets to make: the run below chose `watch_list_sources`, answered correctly,
+  // and was recorded as a failure.
   const before = turnsTaken
   const perception = await turn(sessionId,
-    'Look at what has been indexed and tell me what sources are available to you, '
-    + 'citing anything you find by its timestamp.')
-  const perceptionCalls = await receiptsFor(sessionId, 'watch_search_sources')
+    `There is a short video indexed under media/. Find what on-screen text it `
+    + `contains and tell me the timestamp it appears at.`)
+  await wait(2_500)
+  const perceptionTools = toolsIn(journalled(RECEIPTS))
+  const reachedCore = Object.keys(perceptionTools).filter(name => name.startsWith('watch_'))
   claim('LJ-13 a perception request reached Core through a tool the model chose',
-    perception.settled && perceptionCalls.length >= 1,
-    { settled: perception.settled, calls: perceptionCalls.length, turnsUsed: turnsTaken - before })
+    perception.settled && reachedCore.some(name => name !== 'watch_verify'),
+    { settled: perception.settled, watchTools: reachedCore, turnsUsed: turnsTaken - before })
+
+  const readText = existsSync(join(repo, '..', 'seen.txt'))
+    ? readFileSync(join(repo, '..', 'seen.txt'), 'utf8')
+    : null
+  notes.perceptionAnswer = readText
 
   // ── 8. a bounded delegated task ────────────────────────────────────────────
+  //
+  // Named explicitly, because delegation is the capability under test rather
+  // than a preference being measured. Asked as "delegate this to a sub-task",
+  // one run spawned a subagent and the next did the work itself with `glob` --
+  // both correct answers to that instruction, and only one of them exercises
+  // the thing. What stays the model's choice is how it runs the child.
   const delegated = await turn(sessionId,
-    'Delegate this to a sub-task and report back in one sentence: count how many '
-    + 'JSON files are under owner-test and name them.')
-  const subagent = await receiptsFor(sessionId, 'task')
-  claim('LJ-14 a delegated task ran within the budget',
-    delegated.settled,
-    { settled: delegated.settled, reason: delegated.reason, subagentReceipts: subagent.length })
+    'Use your subagent tool to delegate this to a child task, and report back in '
+    + 'one sentence what it found: how many JSON files are under owner-test, and '
+    + 'what they are called.')
+  await wait(2_500)
+  const afterDelegation = toolsIn(journalled(RECEIPTS))
+  claim('LJ-14 a delegated task ran, and the delegation is in the record',
+    delegated.settled && (afterDelegation.subagent ?? afterDelegation.task ?? 0) >= 1,
+    { settled: delegated.settled, reason: delegated.reason, tools: afterDelegation })
 
   // ── 9. stopping a running task ─────────────────────────────────────────────
   await rpc('session.prompt', { sessionId, mode: 'queue', content: [{ type: 'text',

--- a/workspace/tests/cli.test.mjs
+++ b/workspace/tests/cli.test.mjs
@@ -232,13 +232,20 @@ describe('the commands with side effects refuse before they do harm', () => {
     }
   })
 
-  test('desktop says where the app comes from rather than pretending to fetch one', () => {
+  test('desktop admits there is no application rather than sending somebody to find one', () => {
+    // It used to say the app arrives "from a platform installer" and to install
+    // it "from the project releases". No release has ever carried a desktop
+    // asset, `@deepwatch/desktop` is private, and the electron-builder block in
+    // its manifest names a builder that is not a dependency and that no script
+    // runs -- so that sentence sent a person looking for a file nobody makes.
     const box = sandbox()
     try {
       const ran = deepwatch(['desktop'], { DEEPWATCH_HOME: box.dir })
       assert.equal(ran.code, 2)
-      assert.match(ran.stderr, /platform installer/)
+      assert.match(ran.stderr, /does not distribute a desktop application/)
       assert.match(ran.stderr, /deepwatch web/, 'it names the thing that does work now')
+      assert.doesNotMatch(ran.stderr, /from the project releases/,
+        'there is no release asset to send anybody to')
     } finally {
       box.dispose()
     }

--- a/workspace/tests/first-publish.test.mjs
+++ b/workspace/tests/first-publish.test.mjs
@@ -1,16 +1,44 @@
-/** The irreversible first-publish path is held to its offline contract. */
+/**
+ * The irreversible first-publish path is held to its offline contract.
+ *
+ * The bootstrap exists for one npm ordering: a Trusted Publisher is configured
+ * on a package, and a package that has never been published has no page to
+ * configure it on. So the first upload of each of the twenty is made from a
+ * machine, once, and everything after it goes through the workflow.
+ *
+ * That makes this the least-tested and least-reversible code in the repository,
+ * which is a bad pair. What is held here is the set of mistakes that cost a
+ * version each: a registry decision made on a version *string*, an error read
+ * as an absence, a read-only probe reported as a permission, and a diagnostic
+ * thrown away and replaced with advice that does not apply.
+ */
 
 import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { test } from 'node:test'
+import { test, describe } from 'node:test'
 
-import { EXPECTED_ORDER, distTag } from '../scripts/first-publish.mjs'
+import { EXPECTED_ORDER, distTag, sanitize } from '../scripts/first-publish.mjs'
 import { publishOrder } from '../scripts/publish-order.mjs'
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
 const SOURCE = readFileSync(join(ROOT, 'scripts', 'first-publish.mjs'), 'utf8')
+
+/**
+ * The same file with its prose removed.
+ *
+ * The assertions below come in two kinds, and only one of them may read a
+ * comment. "This behaviour is present" is fine to find anywhere. "This
+ * behaviour is gone" is not: this repository documents a removed mistake by
+ * quoting it, so `access: 'verified'` and the stock token sentence both still
+ * appear in the file — inside the paragraphs explaining why they were taken
+ * out. A rule that failed on those would be a rule against writing down what
+ * went wrong.
+ */
+const CODE = SOURCE
+  .replace(/\/\*[\s\S]*?\*\//g, '')
+  .replace(/^\s*\/\/.*$/gm, '')
 
 test('the bootstrap order is the approved dependency order for all 20 packages', () => {
   assert.equal(EXPECTED_ORDER.length, 20)
@@ -42,7 +70,7 @@ test('the dist-tag is derived from the version, never hardcoded', () => {
   // published under `preview` leaves `npm i @deepwatch/cli` resolving nothing,
   // because `latest` would never exist.
   assert.match(publishCall(), /'--tag', distTag\(/)
-  assert.doesNotMatch(SOURCE, /'--tag', 'preview'/)
+  assert.doesNotMatch(CODE, /'--tag', 'preview'/)
 
   assert.equal(distTag('0.1.0'), 'latest')
   assert.equal(distTag('1.4.0'), 'latest')
@@ -61,9 +89,98 @@ test('a partial run records created, skipped, failed and remaining packages', ()
   assert.match(SOURCE, /saveState\(statePath, state\)/)
 })
 
-test('access probes do not print an npm identity or configuration', () => {
-  assert.match(SOURCE, /'whoami'/)
-  assert.match(SOURCE, /'access', 'list', 'packages', '@deepwatch'/)
-  assert.ok(!SOURCE.includes('process.stdout.write(identity'))
-  assert.ok(!SOURCE.includes('process.stdout.write(access'))
+describe('one registry policy, and it is not this file\'s own', () => {
+  test('the decision comes from publish-plan, not from a second opinion here', () => {
+    // It had its own, and the two disagreed in both directions. This script
+    // ran `npm view <name>@<version> version` and branched on the exit code:
+    // zero meant "skip, already exists" and non-zero meant "publish, absent".
+    assert.match(SOURCE, /import \{ buildPlan \} from '\.\/publish-plan\.mjs'/)
+    assert.match(SOURCE, /buildPlan\(\{ artifacts \}\)/)
+  })
+
+  test('no version-string existence check survives anywhere in the file', () => {
+    // The exact shape that skipped a version published from a different
+    // commit. `publish-plan.mjs` asks for `dist` and compares integrity;
+    // asking for `version` can only ever answer "something is there".
+    assert.doesNotMatch(CODE, /'view',[^\n]*'version'/)
+    assert.doesNotMatch(CODE, /already_exists/)
+  })
+
+  test('a refusal stops the run before the first upload', () => {
+    assert.match(SOURCE, /the registry plan refuses this set/)
+    assert.ok(SOURCE.indexOf('planRegistry(artifacts)') < SOURCE.indexOf("'publish', join(artifacts"),
+      'the plan is built before anything is published')
+  })
+})
+
+describe('a read-only probe is not a permission', () => {
+  test('access probes do not print an npm identity or configuration', () => {
+    assert.match(SOURCE, /'whoami'/)
+    assert.match(SOURCE, /'access', 'list', 'packages', '@deepwatch'/)
+    assert.ok(!SOURCE.includes('process.stdout.write(identity'))
+    assert.ok(!SOURCE.includes('process.stdout.write(access'))
+  })
+
+  test('a successful scope listing is never reported as verified access', () => {
+    // For an empty scope, `npm access list packages @deepwatch` exits zero and
+    // prints nothing -- which is exactly the state in which nothing has been
+    // verified. It was recorded as `access: 'verified'`.
+    assert.doesNotMatch(CODE, /access: 'verified'/)
+    assert.match(SOURCE, /publishPermission: 'not_provable_before_upload'/)
+  })
+
+  test('an account outside the organisation is refused rather than attempted', () => {
+    assert.match(SOURCE, /not_a_member/)
+    assert.match(SOURCE, /cannot publish into the @deepwatch scope/)
+  })
+})
+
+describe('npm gets to say what went wrong', () => {
+  test('a failing probe reports npm\'s own output, not a stock token request', () => {
+    // One sentence -- "authenticate with a short-lived, 2FA-protected
+    // publisher token" -- was the answer to an expired session, a 403 from
+    // the wrong account, a proxy refusing CONNECT and a registry that was
+    // down. Three of those are not fixed by making a token.
+    assert.match(SOURCE, /npm said:/)
+    assert.match(SOURCE, /credential will not help/)
+    assert.doesNotMatch(CODE, /authenticate with a short-lived, 2FA-protected publisher token/)
+  })
+
+  test('the existing authenticated session is the supported path', () => {
+    assert.match(SOURCE, /npm login --registry=https:\/\/registry\.npmjs\.org\/ --auth-type=web/)
+  })
+
+  test('a failed publish prints the diagnostics it tells the operator to read', () => {
+    assert.match(SOURCE, /process\.stderr\.write\(`\\nnpm refused/)
+    assert.match(SOURCE, /diagnostics\(result\)/)
+  })
+
+  test('local uploads are never described as attested', () => {
+    assert.match(SOURCE, /carry no registry provenance attestation/)
+    assert.doesNotMatch(CODE, /--provenance/)
+  })
+})
+
+describe('diagnostics are sanitized before they reach a console or a state file', () => {
+  test('npm tokens, authTokens, bearer headers and URL credentials are removed', () => {
+    const dirty = [
+      'npm error need auth npm_abcdefghijklmnopqrstuvwxyz012345',
+      '//registry.npmjs.org/:_authToken=npm_SECRETSECRETSECRET1234',
+      'authorization: Bearer eyJhbGciOi.eyJzdWIiOiIx.SflKxwRJSMeKKF2QT4',
+      'request to https://user:hunter2@proxy.internal:8080 failed',
+    ].join('\n')
+    const clean = sanitize(dirty)
+    assert.doesNotMatch(clean, /npm_abcdefghijklmnopqrstuvwxyz012345/)
+    assert.doesNotMatch(clean, /npm_SECRETSECRETSECRET1234/)
+    assert.doesNotMatch(clean, /SflKxwRJSMeKKF2QT4/)
+    assert.doesNotMatch(clean, /hunter2/)
+    // And it is still a diagnostic: the reason survives the redaction.
+    assert.match(clean, /need auth/)
+    assert.match(clean, /failed/)
+  })
+
+  test('an ordinary registry error passes through intact', () => {
+    const said = 'npm error code E403\nnpm error 403 Forbidden - PUT https://registry.npmjs.org/@deepwatch%2fcli'
+    assert.equal(sanitize(said), said)
+  })
 })

--- a/workspace/tests/pending-release-claims.test.mjs
+++ b/workspace/tests/pending-release-claims.test.mjs
@@ -1,8 +1,9 @@
 /**
- * No page tells a visitor to install something that is not published.
+ * No page tells a visitor to install something that is not published, and no
+ * page tells a visitor something is unpublished once it is.
  *
  * The README's first instruction was `npm install -g @deepwatch/cli`, written
- * plainly, with an npm version badge above it. Nothing exists under the
+ * plainly, with an npm version badge above it. Nothing existed under the
  * `@deepwatch` scope — the twenty packages are published for the first time by
  * the `deepwatch-v0.1.0` tag — so the first thing a visitor did was run a
  * command that resolves nothing, on the page that was supposed to introduce
@@ -13,14 +14,27 @@
  * and `docs/releasing.md` states it as a rule: *no document in this repository
  * may say it does*. The README disagreed with both, and nothing checked.
  *
- * So this is the check. Every registry install command naming the `@deepwatch`
- * scope has to sit under a statement that it is pending a release. Not a
+ * So this is the check — and it has two halves, because a release train has
+ * two ways to lie about a registry and this file was written knowing only one
+ * of them.
+ *
+ * **Before publication**, every registry install command naming the
+ * `@deepwatch` scope has to sit under a statement that it is pending. Not a
  * disclaimer at the bottom of the page — within a dozen lines, where somebody
  * about to copy the command will read it.
  *
- * The rule is deliberately about *this* scope and *this* moment. When the
- * first publication happens, these markers come out, and the failure of this
- * test is the reminder to take them out.
+ * **After publication**, the same markers become the lie. A page still saying
+ * "not on npm yet" about a scope that is live sends a reader to a checkout
+ * build they do not need, and it is exactly the kind of sentence nobody
+ * re-reads. So the rule inverts on one switch: `deepwatch.registryStatus` in
+ * the workspace manifest, which is also what `gen-package-docs.mjs` reads.
+ *
+ * The same mistake has a second shape, and Watch Skill made it. `watch-skill`
+ * *is* published, so its honest note was never "pending" but "which version
+ * you actually get" — and the moment `core-v1.4.0` reached PyPI, three pages
+ * went on saying the newest release was 1.2.0. A currency claim about a
+ * registry is a fact with an expiry date, and the last test here is what
+ * notices when one expires.
  */
 
 import { test, describe } from 'node:test'
@@ -32,6 +46,19 @@ import { fileURLToPath } from 'node:url'
 
 const WORKSPACE = join(dirname(fileURLToPath(import.meta.url)), '..')
 const REPO = join(WORKSPACE, '..')
+
+/** The one switch. `unpublished` while the scope is empty, `published` after. */
+const REGISTRY_STATUS
+  = JSON.parse(readFileSync(join(WORKSPACE, 'package.json'), 'utf8'))
+    .deepwatch?.registryStatus ?? 'published'
+
+/** The Core version this repository declares, which is what PyPI should hold. */
+function declaredCoreVersion() {
+  const text = readFileSync(join(REPO, 'pyproject.toml'), 'utf8')
+  const match = /^version\s*=\s*"([^"]+)"/m.exec(text)
+  assert.notEqual(match, null, 'pyproject.toml declares no version')
+  return match[1]
+}
 
 /**
  * How far above a command a reader is credited with looking.
@@ -46,7 +73,7 @@ const NEARBY_LINES = 12
 const INSTALL = /(?:npm\s+(?:install|i|exec)|npx|pnpm\s+(?:add|dlx)|yarn\s+(?:add|dlx)|bun\s+(?:add|x)|dsh\s+plugin\b[^\n]*\badd)\b[^\n]*@deepwatch\//
 
 /**
- * The claim that makes such a command honest today.
+ * The claim that makes such a command honest before publication.
  *
  * Phrased loosely on purpose. The first version of this list enumerated the
  * exact sentences the README used, and then failed on
@@ -55,7 +82,7 @@ const INSTALL = /(?:npm\s+(?:install|i|exec)|npx|pnpm\s+(?:add|dlx)|yarn\s+(?:ad
  * had not been told about. A guard against dishonest documentation should not
  * also be a style guide for how to be honest.
  */
-const PENDING = /not on npm yet|not published yet|are not published|pending[^\n]{0,40}release|first publication|has never published|never published/i
+const PENDING = /not on npm yet|not published yet|are not published|pending[^\n]{0,40}release|first publication|has never published|never published|does not exist yet|nothing exists under/i
 
 /** Documentation, as the release-surface gate defines it, minus its history. */
 function documents() {
@@ -74,20 +101,28 @@ function documents() {
     .filter(line => !line.endsWith('tests/pending-release-claims.test.mjs'))
 }
 
-describe('an unpublished package is never presented as installable', () => {
+/** A line that is itself saying the command does not work. */
+function disclaims(line) {
+  if (PENDING.test(line)) return true
+  return /\b(?:do not|does not|cannot|must not|there is no|never)\b/i.test(line)
+}
+
+describe('an unpublished package is never presented as installable', {
+  skip: REGISTRY_STATUS === 'published'
+    ? 'the @deepwatch scope is published; the inverse rule applies'
+    : false,
+}, () => {
   test('every @deepwatch install command is marked pending, near enough to read', () => {
     const offenders = []
     for (const relative of documents()) {
       const lines = readFileSync(join(REPO, relative), 'utf8').split(/\r?\n/)
       lines.forEach((line, index) => {
         if (!INSTALL.test(line)) return
-        // A line that is itself saying the command does not work. These read
-        // naturally in several shapes -- "there is no `npx @deepwatch/cli`",
-        // "`npx @deepwatch/cli` does not work today" -- and a rule that only
-        // recognised one of them would flag the very sentences it exists to
-        // require.
-        if (PENDING.test(line)) return
-        if (/\b(?:do not|does not|cannot|must not|there is no|never)\b/i.test(line)) return
+        // These read naturally in several shapes -- "there is no
+        // `npx @deepwatch/cli`", "`npx @deepwatch/cli` does not work today" --
+        // and a rule that only recognised one of them would flag the very
+        // sentences it exists to require.
+        if (disclaims(line)) return
         const context = lines.slice(Math.max(0, index - NEARBY_LINES), index + 1).join('\n')
         if (PENDING.test(context)) return
         offenders.push(`${relative}:${String(index + 1)}: ${line.trim()}`)
@@ -97,14 +132,10 @@ describe('an unpublished package is never presented as installable', () => {
       'these tell a visitor to install a package that does not exist yet')
   })
 
-  test('the README says it in both halves, because it has two entry paths', () => {
+  test('the README says it where the npm entry path is', () => {
     const readme = readFileSync(join(REPO, 'README.md'), 'utf8')
     assert.match(readme, /\*\*Not on npm yet\.\*\*/)
     assert.match(readme, /deepwatch-v0\.1\.0/)
-    // And the other train, which is the opposite mistake: `watch-skill` *is*
-    // published, so the honest note is which version a visitor actually gets.
-    assert.match(readme, /\*\*On PyPI, one version behind\.\*\*/)
-    assert.match(readme, /core-v1\.4\.0/)
   })
 
   test('the working path today is named, not just the pending one', () => {
@@ -122,5 +153,82 @@ describe('an unpublished package is never presented as installable', () => {
     assert.match(releasing, /no document in this repository may\s*\n?\s*say it does/)
     const started = readFileSync(join(WORKSPACE, 'docs', 'getting-started.md'), 'utf8')
     assert.match(started, /packages are not published yet/)
+  })
+})
+
+describe('a published package is never presented as pending', {
+  skip: REGISTRY_STATUS === 'unpublished'
+    ? 'the @deepwatch scope is still empty; the pending rule applies'
+    : false,
+}, () => {
+  test('no page still says the @deepwatch scope holds nothing', () => {
+    const offenders = []
+    for (const relative of documents()) {
+      const lines = readFileSync(join(REPO, relative), 'utf8').split(/\r?\n/)
+      lines.forEach((line, index) => {
+        if (!/@deepwatch|DeepWatch/.test(line)) return
+        if (!PENDING.test(line)) return
+        offenders.push(`${relative}:${String(index + 1)}: ${line.trim()}`)
+      })
+    }
+    assert.deepEqual(offenders, [],
+      'the scope is published; these still tell a reader it is not')
+  })
+
+  test('the README shows the install command with no pending caveat over it', () => {
+    const readme = readFileSync(join(REPO, 'README.md'), 'utf8')
+    assert.match(readme, /npm install -g @deepwatch\/cli/)
+    assert.doesNotMatch(readme, /\*\*Not on npm yet\.\*\*/)
+  })
+})
+
+describe('a currency claim about a registry has an expiry date', () => {
+  /**
+   * Sentences that say what a registry holds *now*.
+   *
+   * Not every version number in a document is a claim about the present. A
+   * changelog entry, a compatibility range and an upgrade example all name
+   * old versions legitimately. What expires is the shape "the newest
+   * published version is X" -- so that shape is what is matched, and a line
+   * that marks itself as a past observation ("on 2026-09-05 it was") is left
+   * alone.
+   */
+  const CURRENCY = /\b(?:newest|latest|current)\b[^.\n]{0,60}\b(?:publish|release|on PyPI)/i
+  const HISTORICAL = /\bon 20\d\d-\d\d-\d\d\b|\bat the time\b|\bused to\b|\bwas\b/i
+  const SEMVER = /\b(\d+)\.(\d+)\.(\d+)(rc|a|b|\.dev)?\d*\b/g
+
+  function older(version, than) {
+    const left = version.split('.').map(Number)
+    const right = than.split('.').map(Number)
+    for (let at = 0; at < 3; at += 1) {
+      if (left[at] !== right[at]) return left[at] < right[at]
+    }
+    return false
+  }
+
+  test('no page says PyPI holds a Watch Skill older than the one declared here', () => {
+    const declared = declaredCoreVersion()
+    const offenders = []
+    for (const relative of documents()) {
+      const text = readFileSync(join(REPO, relative), 'utf8')
+      // Sentences, not lines: these claims wrap, and half of one reads as
+      // neither a currency claim nor a version.
+      for (const sentence of text.split(/(?<=[.!?])\s+/)) {
+        if (!CURRENCY.test(sentence)) continue
+        if (HISTORICAL.test(sentence)) continue
+        if (!/watch-skill|PyPI/i.test(sentence)) continue
+        for (const match of sentence.matchAll(SEMVER)) {
+          // A prerelease is never the answer to "what does `pip install` give
+          // you", so naming one is not a currency claim about the stable line.
+          if (match[4] !== undefined) continue
+          const found = `${match[1]}.${match[2]}.${match[3]}`
+          if (older(found, declared)) {
+            offenders.push(`${relative}: names ${found} where ${declared} is published`)
+          }
+        }
+      }
+    }
+    assert.deepEqual(offenders, [],
+      `PyPI holds watch-skill ${declared}; these pages still name an older release as current`)
   })
 })

--- a/workspace/tests/release-workflow.test.mjs
+++ b/workspace/tests/release-workflow.test.mjs
@@ -254,6 +254,85 @@ describe('what reaches the registry, and in what order', () => {
   })
 })
 
+describe('the npm release ends in something a person can link to', () => {
+  test('DeepWatch completes a GitHub Release, and only after npm accepted', () => {
+    // This train had no release job at all. Twenty packages reached the
+    // registry and the tag that published them stayed a bare tag: nothing to
+    // link, and — the one that mattered — no file to download for anybody
+    // installing the bundle into an existing Harness without a registry.
+    const release = job(DEEPWATCH, 'github-release')
+    assert.match(release, /needs: \[verify, publish\]/)
+    assert.match(release, /action-gh-release/)
+    assert.match(release, /contents: write/)
+
+    // Announcement after publication, the same ordering Core had to be
+    // corrected into. The verify job must not create it.
+    assert.ok(!job(DEEPWATCH, 'verify').includes('action-gh-release'))
+    assert.ok(!job(DEEPWATCH, 'publish').includes('action-gh-release'))
+  })
+
+  test('the assets are the sealed set, checked again on the way out', () => {
+    const release = job(DEEPWATCH, 'github-release')
+    assert.match(release, /sha256sum -c SHA256SUMS/)
+    assert.ok(release.indexOf('sha256sum -c SHA256SUMS') < release.indexOf('action-gh-release'),
+      'the digests must be checked before the assets are attached')
+    assert.ok(!release.includes('npm run pack'), 'the release job must not build anything')
+
+    // The tarballs are the DSH distribution. There is no separate archive
+    // format, and inventing one by renaming a `.tgz` would be a format nothing
+    // reads.
+    assert.match(release, /\*\.tgz/)
+    assert.match(release, /SHA256SUMS/)
+    assert.match(release, /provenance\.json/)
+  })
+
+  test('a prerelease is labelled one, from the dist-tag the tag earned', () => {
+    const release = job(DEEPWATCH, 'github-release')
+    assert.match(release, /prerelease: \$\{\{ needs\.verify\.outputs\.dist-tag != 'latest' \}\}/)
+  })
+
+  test('the release notes describe the set that was sealed, not a remembered one', () => {
+    const verify = job(DEEPWATCH, 'verify')
+    assert.match(verify, /gen-release-notes\.mjs/)
+    assert.ok(verify.indexOf('npm run release:seal') < verify.indexOf('gen-release-notes.mjs'),
+      'the notes are written from the sealed inventory')
+    assert.match(job(DEEPWATCH, 'github-release'), /body_path/)
+  })
+
+  test('a partial npm release is reported as the state it is', () => {
+    const report = job(DEEPWATCH, 'report')
+    assert.match(report, /if: always\(\)/)
+    assert.match(report, /This release is incomplete/)
+    assert.match(report, /\[ "\$PUBLISH" = "success" \]/)
+  })
+})
+
+describe('one repository, two trains, and no crossed wires', () => {
+  test('the published smoke ignores a release from the other train', () => {
+    // `release: published` carries no tag filter, and this workflow stripped
+    // `core-v` from whatever tag arrived. A `deepwatch-v0.1.0` release
+    // therefore asked PyPI for `watch-skill` version `deepwatch-v0.1.0`,
+    // sixty times over ten minutes, and failed — a red check on a release that
+    // had done nothing wrong.
+    const post = readFileSync(join(WORKFLOWS, 'post-publish.yml'), 'utf8')
+    assert.match(post, /case "\$tag" in\s*\n\s*core-v\*\)/)
+    assert.match(post, /is not a Watch Core release/)
+    assert.match(post, /skip=true/)
+    assert.match(post, /if: needs\.version\.outputs\.skip != 'true'/)
+  })
+
+  test('the step whose outputs the jobs read actually has that id', () => {
+    // `outputs: spec: ${{ steps.pick.outputs.spec }}` with no `id: pick` on the
+    // step resolves to an empty string, silently. The workflow has never run,
+    // so nothing had ever noticed.
+    const post = readFileSync(join(WORKFLOWS, 'post-publish.yml'), 'utf8')
+    for (const output of [...post.matchAll(/\$\{\{\s*steps\.([A-Za-z0-9_-]+)\.outputs/g)]) {
+      assert.match(post, new RegExp(`id: ${output[1]}\\b`),
+        `post-publish.yml reads steps.${output[1]}.outputs but has no step with that id`)
+    }
+  })
+})
+
 test('the required workspace result includes the real browser journey', () => {
   const workflow = readFileSync(join(WORKFLOWS, 'workspace-ci.yml'), 'utf8')
   const browser = job(workflow, 'browser-e2e')


### PR DESCRIPTION
Everything between "the packages are built" and "a person can install them",
plus the front page that introduces them.

## Release blockers

**`first-publish.mjs` kept its own opinion of the registry.** It ran
`npm view <name>@<version> version` and branched on the exit code: zero meant
"already published, skip"; non-zero meant "absent, publish". Both halves fail
on a bad day — a version published from a *different commit* wears the same
version string and was skipped silently, and a network blip or an expired
session was read as proof of absence. `publish-plan.mjs` already asks the right
question and already tells `E404` apart from failure, so the bootstrap now asks
it. One policy: publish what is absent, skip what is demonstrably identical,
refuse what conflicts, stop on anything it cannot tell apart.

The access probes claimed more than they established. For an empty scope
`npm access list packages @deepwatch` exits zero and prints nothing — the exact
state where nothing has been verified — and that was recorded as
`access: 'verified'`. It now reports identity and organisation role, and says
npm settles publish permission at the first upload. A failing probe prints
npm's own words, sanitized, instead of one stock request for a token that would
not have helped three of its four causes.

**The npm train had no GitHub Release.** Twenty packages would reach the
registry and the tag would stay a bare tag: nothing to link, and no
downloadable tarball for anyone installing `@deepwatch/dsh-bundle` into an
existing Harness without reaching a registry. There is now a `github-release`
job — after publication, the way Core's is — attaching the sealed set with
notes composed from the inventory, plus a `report` job that states a partial
release as the state it is.

**`post-publish.yml` read the other train's tag.** `release: published` carries
no filter and the workflow stripped `core-v` from whatever arrived, so a
`deepwatch-v0.1.0` release would have asked PyPI for `watch-skill` version
`deepwatch-v0.1.0` sixty times over ten minutes and then failed. While reading
it: the step whose outputs both jobs consume had no `id`, so
`steps.pick.outputs.*` was always empty. The workflow has never run, so nothing
had noticed either.

**The release-claims guard expired with the claim it guarded.** It asserted the
README's "On PyPI, one version behind" sentence verbatim, so publishing
`core-v1.4.0` broke it. It now reads facts instead: the npm half turns on
`deepwatch.registryStatus` and inverts after publication rather than
disappearing, and the PyPI half compares any currency claim against the version
`pyproject.toml` declares. It found two pages the release had already outrun.

## Presentation

The README had become a record of how the release was argued into shape. It now
leads with the product: what it is, a badge row carrying real numbers, and a
table that routes a reader to one of three entry paths instead of making them
read all three. The agent integration avatars are back, curated to ten with a
link to the matrix; both loop GIFs are back; the twenty-example index moves
into a `<details>`.

Two claims were wrong rather than merely long. "Nothing learns between runs"
erased a feature that ships — a correction becomes a classified lesson, applied
on re-ask, counted in the savings meter; what does not exist is *autonomous*
learning. And the provider section generalised about local versus hosted models
in a way the product does not support.

`docs/ecosystem.md` becomes four categories and stops labelling the video
coverage "not verified": Bilibili returns 412 to every programmatic request and
Toutiao renders client-side, which is a fact about those sites. Its metrics
section names the four numbers that get confused with each other.

## Package documentation

`gen-package-docs.mjs` composed twenty pages from the manifest alone, so twenty
pages said the same four things. It now merges three sources — the manifest,
the `Config` interface parsed out of `src/index.ts` with its doc comments, and
a new `docs/package-notes.json` for the prose a manifest cannot carry. Every
page opens by saying whether it is a thing you install or a thing that arrived
in your tree, and the configuration table cannot drift from the code that
defines it. `docs/packages.md` is the map of all twenty.

## Checks

`npm run check` is green locally: 2389 tests pass, 5 skipped, 0 fail.
