### PR TITLE
The tag's gate job never had what the gates need

### DIFF
--- a/.github/workflows/release-deepwatch.yml
+++ b/.github/workflows/release-deepwatch.yml
@@ -107,6 +107,32 @@ jobs:
           version: 10.29.1
       - run: pnpm install --frozen-lockfile
 
+      # The same preparation the gate job in workspace-ci does, because it runs
+      # the same `npm run check`.
+      #
+      # Core importable, so the cross-language contract is checked rather than
+      # skipped: `workspace-canonical.test.mjs` compares the launcher's idea of
+      # the workspace root with Core's, through a Python subprocess.
+      - uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.11"
+      - name: Core importable
+        working-directory: .
+        run: uv sync
+
+      # And the pinned upstream, because inventory generation and parity
+      # diffing read the DSH source rather than a description of it.
+      # `upstream/deepseek-harness/` is not committed, so a fresh checkout has
+      # none — which is every checkout this job ever makes.
+      #
+      # Left out, `npm run check` stops at `inventory:check` with "upstream
+      # checkout missing", and it stopped there on the first `deepwatch-v0.1.0`
+      # tag. Nothing was published, because every publishing step is gated on
+      # this job, which is the design working — but the release train had never
+      # been run end to end, and this is the step it was missing.
+      - name: Pinned upstream baseline
+        run: node scripts/upstream-sync.mjs
+
       - name: Every gate, before anything is packed
         run: npm run check
 

--- a/workspace/tests/release-workflow.test.mjs
+++ b/workspace/tests/release-workflow.test.mjs
@@ -337,6 +337,40 @@ describe('the sealed set survives the round trip through an artifact', () => {
   })
 })
 
+describe('the release runs the gates the way CI runs them', () => {
+  test('the verify job prepares `npm run check` the way the gate job does', () => {
+    // Both jobs run the same `npm run check`, and that command needs two
+    // things a bare checkout does not have. `upstream/deepseek-harness/` is
+    // not committed, so inventory generation and parity diffing have nothing
+    // to read; and without an importable Core the cross-language workspace
+    // contract skips instead of running.
+    //
+    // workspace-ci does both. The release train did neither, and the first
+    // `deepwatch-v0.1.0` tag stopped at `inventory:check` with "upstream
+    // checkout missing". Nothing was published — every publishing step is
+    // gated on that job — but the release could not complete either.
+    const workspace = readFileSync(join(WORKFLOWS, 'workspace-ci.yml'), 'utf8')
+    const gate = job(workspace, 'check')
+    const verify = job(DEEPWATCH, 'verify')
+
+    for (const [needle, why] of [
+      ['scripts/upstream-sync.mjs', 'the pinned upstream the inventory gates read'],
+      ['astral-sh/setup-uv', 'a Python the cross-language contract can import'],
+    ]) {
+      assert.ok(gate.includes(needle), `workspace-ci's gate job no longer does: ${why}`)
+      assert.ok(verify.includes(needle),
+        `the release verify job runs \`npm run check\` without ${why}`)
+    }
+
+    // And the preparation has to come first, or it prepares nothing. Read
+    // from the steps rather than the file: the comment explaining this fix
+    // names `npm run check`, and a text search finds the prose before the run.
+    const steps = verify.split('\n').filter(line => !/^\s*#/.test(line)).join('\n')
+    assert.ok(steps.indexOf('upstream-sync.mjs') < steps.indexOf('npm run check'),
+      'the upstream is synced before the gates that read it')
+  })
+})
+
 describe('the npm release ends in something a person can link to', () => {
   test('DeepWatch completes a GitHub Release, and only after npm accepted', () => {
     // This train had no release job at all. Twenty packages reached the


### PR DESCRIPTION
The first `deepwatch-v0.1.0` tag stopped in `verify` at `inventory:check` with *upstream checkout missing*. **Nothing was published** — every publishing step is gated on that job, so the design held. But the release train had never run end to end, and this is the step it was missing.

`npm run check` needs two things a bare checkout lacks: the pinned `upstream/deepseek-harness/` (not committed, and read by inventory generation and parity diffing), and an importable Core (without which the cross-language workspace-root contract skips instead of running).

`workspace-ci.yml`'s gate job does both — its comment even records that a cold clone proved the first. The release job ran the same `npm run check` with neither.

A test now asserts the two jobs agree, checking both sides, so it fails whichever one drifts.