### PR TITLE
Download outside the checkout, and let npm own the terminal

### DIFF
--- a/.github/workflows/release-deepwatch.yml
+++ b/.github/workflows/release-deepwatch.yml
@@ -271,10 +271,19 @@ jobs:
           npm install --global npm@11.17.0
           npm --version
 
+      # Downloaded outside the checkout, and that is load-bearing.
+      #
+      # `path: workspace-artifacts` put twenty-five files inside the working
+      # tree. They are not in any `.gitignore`, so the very next step --
+      # `verify-provenance.mjs`, which refuses a tree that cannot honestly name
+      # the source of its own artifacts -- counted them and rejected the
+      # release with `worktree_dirty`. The check was right; the download was in
+      # the wrong place. `.release-artifacts/` and the manifest beside it are
+      # both ignored, which is why the verify job never hit this.
       - uses: actions/download-artifact@v8
         with:
           name: deepwatch-tarballs
-          path: workspace-artifacts
+          path: ${{ runner.temp }}/sealed
 
       - name: Put the sealed set back where the manifest describes it
         run: |
@@ -284,14 +293,17 @@ jobs:
           # The upload staged a flat, visible directory; the manifest describes
           # a hidden one. Restoring the shape here keeps every script that
           # reads `.release-artifacts` unchanged.
-          cp ../workspace-artifacts/*.tgz .release-artifacts/
-          cp ../workspace-artifacts/SHA256SUMS .release-artifacts/
-          cp ../workspace-artifacts/packed-artifacts.json .release-artifacts/
-          cp ../workspace-artifacts/publish-plan.json .release-artifacts/
-          cp ../workspace-artifacts/release-notes.md .release-artifacts/
-          cp ../workspace-artifacts/provenance.json .release-artifacts-provenance.json
+          cp "$RUNNER_TEMP"/sealed/*.tgz .release-artifacts/
+          cp "$RUNNER_TEMP"/sealed/SHA256SUMS .release-artifacts/
+          cp "$RUNNER_TEMP"/sealed/packed-artifacts.json .release-artifacts/
+          cp "$RUNNER_TEMP"/sealed/publish-plan.json .release-artifacts/
+          cp "$RUNNER_TEMP"/sealed/release-notes.md .release-artifacts/
+          cp "$RUNNER_TEMP"/sealed/provenance.json .release-artifacts-provenance.json
           ls -l .release-artifacts
           test "$(ls .release-artifacts/*.tgz | wc -l)" -eq 20
+          # The tree has to still be clean, because the next step refuses a
+          # dirty one and this step is the only thing that touched it.
+          test -z "$(git -C .. status --porcelain=v1 --untracked-files=all)"             || { echo "::error::restoring the sealed set left the worktree dirty";                  git -C .. status --porcelain=v1 --untracked-files=all; exit 1; }
 
       # The manifest is checked before the first upload, not after. A publish
       # job that trusts whatever arrived in an artifact is a publish job that

--- a/workspace/docs/releasing.md
+++ b/workspace/docs/releasing.md
@@ -200,9 +200,26 @@ locally at all:
      --expect-commit "$(git rev-parse HEAD)"
    ```
 
-3. **Publish those exact files**, with
+3. **Publish those exact files**, from a terminal you are sitting at, with
    `node scripts/first-publish.mjs --artifacts sealed --publish
    --confirm-first-publish`.
+
+   *A terminal, specifically.* npm's `otplease` wrapper
+   (`lib/utils/auth.js`) rethrows an authentication error before attempting
+   its browser flow when either stdin or stdout is not a TTY:
+
+   ```js
+   if (!process.stdin.isTTY || !process.stdout.isTTY) { throw err }
+   ```
+
+   Run from a captured pipe — a CI step, an agent, anything reading the
+   output — the publish fails with a bare `EOTP: This operation requires a
+   one-time password` for an account that can publish perfectly well, and
+   never offers the challenge that would have completed it. The script now
+   refuses up front rather than letting you discover this on package one.
+   Everything else it does stays captured and sanitized; only the upload
+   hands npm the terminal, and no one-time password passes through the
+   script, its arguments, or its state file.
 4. **Configure the Trusted Publishers** (below). This needs interactive 2FA —
    `npm trust` refuses a token that bypasses it.
 5. **Re-run the workflow.** It packs the same bytes, the plan says `skip`

--- a/workspace/scripts/first-publish.mjs
+++ b/workspace/scripts/first-publish.mjs
@@ -136,12 +136,69 @@ export function distTag(version) {
   return 'latest'
 }
 
+/**
+ * A read-only npm probe, with its output captured so it can be sanitized.
+ *
+ * Everything this script asks npm *about* goes through here: identity,
+ * organisation role, scope listing. Capturing is right for those — the answers
+ * are inspected, and anything credential-shaped has to be removed before it
+ * reaches a console or a state file.
+ */
 function npm(args) {
   const spec = resolveNpm()
   if (spec === null) {
     return { code: 1, stdout: '', stderr: 'npm is unavailable: nothing named npm is on PATH' }
   }
   return run(spec.command, [...spec.prefix, ...args], { cwd: ROOT })
+}
+
+/**
+ * Whether npm can run an authentication challenge from here.
+ *
+ * npm's `otplease` wrapper (`lib/utils/auth.js`) is the whole reason this
+ * distinction exists. Its first act inside the catch is:
+ *
+ *     if (!process.stdin.isTTY || !process.stdout.isTTY) { throw err }
+ *
+ * — *before* it looks at whether the error is `EOTP` and carries the `authUrl`
+ * and `doneUrl` that drive the browser flow. So on a captured pipe npm never
+ * offers to authenticate; it rethrows, and the caller sees a bare
+ * `EOTP: This operation requires a one-time password` for an account that is
+ * perfectly able to publish. Verified against the npm this script resolves,
+ * 11.17.0.
+ *
+ * That is not a thing `stdio: 'inherit'` can fix on its own: inheriting a pipe
+ * inherits a pipe. The parent has to have a terminal.
+ */
+function interactive() {
+  return Boolean(process.stdin.isTTY) && Boolean(process.stdout.isTTY)
+}
+
+/**
+ * The one npm call that writes, run so npm owns the terminal.
+ *
+ * `stdio: 'inherit'` hands npm this process's stdin and stdout, so when the
+ * registry answers `EOTP` npm can open the browser challenge, wait for it, and
+ * retry the upload with the one-time password it obtained. Nothing about that
+ * exchange passes through this script: no OTP is read here, printed here,
+ * stored here, or accepted as an argument.
+ *
+ * The cost is that npm's output is not captured for this call, so a failure
+ * cannot be summarised into the state file the way a probe's can. That is the
+ * right trade: the operator is watching a terminal, npm's own message is in
+ * front of them, and a captured message they could not have answered is worth
+ * less than an authentication they can complete.
+ */
+function npmInteractive(args) {
+  const spec = resolveNpm()
+  if (spec === null) {
+    return { code: 1, stdout: '', stderr: 'npm is unavailable: nothing named npm is on PATH' }
+  }
+  const result = spawnSync(spec.command, [...spec.prefix, ...args], {
+    cwd: ROOT,
+    stdio: 'inherit',
+  })
+  return { code: result.status ?? 1, stdout: '', stderr: '' }
 }
 
 function gitClean() {
@@ -374,6 +431,27 @@ async function main() {
   }
   if (!confirmed) throw new Error('--publish also requires --confirm-first-publish')
 
+  // Refused here rather than discovered at the first upload.
+  //
+  // Without a terminal npm cannot run an authentication challenge: `otplease`
+  // rethrows before it looks at whether the error is one it could answer. The
+  // symptom is `EOTP` on package one, which reads like a broken credential and
+  // is not — it is a broken *place to run this from*. Saying so up front is the
+  // difference between a five-minute fix and an afternoon spent reissuing
+  // tokens that were never the problem.
+  if (!interactive()) {
+    throw new Error(
+      'this needs a real terminal, and stdin/stdout here are not one.\n\n'
+      + "npm's `otplease` (lib/utils/auth.js) rethrows an authentication error\n"
+      + 'before attempting its browser flow when either stream is not a TTY, so\n'
+      + 'a publish from a captured pipe fails with EOTP and never offers you the\n'
+      + 'challenge you could have completed.\n\n'
+      + 'Run this from a terminal you are sitting at — PowerShell, Windows\n'
+      + 'Terminal, or any shell with a console attached — and npm will open the\n'
+      + 'authentication itself. Nothing about the one-time password passes\n'
+      + 'through this script.')
+  }
+
   // Asked once, before the first upload, and recorded. Between planning and
   // publishing sits nothing but this loop, so re-asking per package would only
   // add twenty round trips and twenty more chances to misread an outage.
@@ -398,18 +476,21 @@ async function main() {
     }
 
     process.stdout.write(`publish   ${item.name}@${item.version}\n`)
-    const result = npm([
+    // npm owns the terminal for this call, so an authentication challenge is
+    // something the operator can answer rather than something that kills the
+    // run. Its output is therefore npm's own, on their screen, uncaptured.
+    const result = npmInteractive([
       'publish', join(artifacts, item.file), '--access', 'public', '--tag', distTag(item.version),
     ])
     if (result.code !== 0) {
-      const said = diagnostics(result)
       state.failed.push({
-        name: item.name, version: item.version, category: 'publish_failed', npm: said,
+        name: item.name, version: item.version, category: 'publish_failed',
+        npm: 'npm wrote to the terminal; its message is above this line',
       })
       saveState(statePath, state)
-      process.stderr.write(`\nnpm refused ${item.name}@${item.version}:\n${said}\n\n`)
       throw new Error(
-        `${item.name} failed. ${String(state.created.length)} package(s) reached the registry `
+        `${item.name} failed — npm's own output is above. `
+        + `${String(state.created.length)} package(s) reached the registry `
         + `and are recorded in ${statePath}. Re-running re-plans against the registry and `
         + 'resumes at the first package that is not already published from this exact build.')
     }

--- a/workspace/tests/first-publish.test.mjs
+++ b/workspace/tests/first-publish.test.mjs
@@ -54,7 +54,7 @@ test('dry-run is the default and publishing needs two explicit flags', () => {
 
 /** The single publish call, for the assertions that read its arguments. */
 function publishCall() {
-  const calls = [...SOURCE.matchAll(/npm\(\[\s*'publish',[\s\S]{0,220}?\]\)/g)]
+  const calls = [...SOURCE.matchAll(/npmInteractive\(\[\s*'publish',[\s\S]{0,220}?\]\)/g)]
   assert.equal(calls.length, 1, 'there must be exactly one publish command')
   return calls[0][0]
 }
@@ -113,6 +113,53 @@ describe('one registry policy, and it is not this file\'s own', () => {
   })
 })
 
+describe('npm can answer for itself when the registry challenges it', () => {
+  // `otplease` in npm's `lib/utils/auth.js` opens with, inside the catch:
+  //
+  //     if (!process.stdin.isTTY || !process.stdout.isTTY) { throw err }
+  //
+  // *before* it checks whether the error is an `EOTP` carrying the `authUrl`
+  // and `doneUrl` that drive its browser flow. Publishing through a captured
+  // pipe therefore fails with a bare EOTP for an account that can publish
+  // perfectly well, and never offers the challenge. Confirmed against the npm
+  // this script resolves, 11.17.0.
+
+  test('the publish call gives npm the terminal', () => {
+    assert.match(SOURCE, /function npmInteractive\(/)
+    assert.match(SOURCE, /stdio: 'inherit'/)
+    // And it is the publish that uses it, not a probe.
+    assert.match(publishCall(), /'publish'/)
+  })
+
+  test('the read-only probes stay captured, so they can be sanitized', () => {
+    for (const probe of ["'whoami'", "'org', 'ls'", "'access', 'list'"]) {
+      const at = SOURCE.indexOf(probe)
+      assert.notEqual(at, -1, `${probe} is gone`)
+      const call = SOURCE.slice(Math.max(0, at - 60), at)
+      assert.match(call, /npm\(\[/,
+        `${probe} must go through the capturing helper, not the interactive one`)
+    }
+    assert.match(SOURCE, /function sanitize\(/)
+  })
+
+  test('a run with no terminal is refused before the first upload', () => {
+    assert.match(SOURCE, /function interactive\(/)
+    assert.match(SOURCE, /this needs a real terminal/)
+    assert.ok(SOURCE.indexOf('if (!interactive())') < SOURCE.indexOf("'publish', join(artifacts"),
+      'the refusal must come before anything is uploaded')
+    // And it explains the cause rather than blaming the credential.
+    assert.match(SOURCE, /otplease/)
+  })
+
+  test('no one-time password is read, stored or accepted as an argument', () => {
+    // The operator answers npm, not this script. An OTP that reached here
+    // would end up in argv, in a log, or in the state file beside the run.
+    assert.doesNotMatch(CODE, /--otp/)
+    assert.doesNotMatch(CODE, /otp\s*[:=]/i)
+    assert.doesNotMatch(CODE, /npm_config_otp/)
+  })
+})
+
 describe('a read-only probe is not a permission', () => {
   test('access probes do not print an npm identity or configuration', () => {
     assert.match(SOURCE, /'whoami'/)
@@ -150,9 +197,18 @@ describe('npm gets to say what went wrong', () => {
     assert.match(SOURCE, /npm login --registry=https:\/\/registry\.npmjs\.org\/ --auth-type=web/)
   })
 
-  test('a failed publish prints the diagnostics it tells the operator to read', () => {
-    assert.match(SOURCE, /process\.stderr\.write\(`\\nnpm refused/)
-    assert.match(SOURCE, /diagnostics\(result\)/)
+  test('a failed publish points at output npm has already written', () => {
+    // This used to assert that the script re-printed a captured message. It
+    // cannot any more, and should not: capturing the publish is what stopped
+    // npm offering an authentication challenge in the first place. npm writes
+    // to the operator's terminal directly, so the script's job is to say where
+    // to look and what state the run is in -- not to paraphrase.
+    assert.match(SOURCE, /npm's own output is above/)
+    assert.match(SOURCE, /npm wrote to the terminal/)
+    assert.match(SOURCE, /package\(s\) reached the registry/)
+    assert.match(SOURCE, /resumes at the first package/)
+    // The captured path is still there, for the probes that are inspected.
+    assert.match(SOURCE, /function diagnostics\(/)
   })
 
   test('local uploads are never described as attested', () => {

--- a/workspace/tests/release-workflow.test.mjs
+++ b/workspace/tests/release-workflow.test.mjs
@@ -310,10 +310,30 @@ describe('the sealed set survives the round trip through an artifact', () => {
 
   test('the publish job restores the shape the manifest describes', () => {
     const publish = job(DEEPWATCH, 'publish')
-    assert.doesNotMatch(publish, /workspace-artifacts\/workspace/,
-      'the artifact is flat; there is no nested workspace directory')
-    assert.match(publish, /cp \.\.\/workspace-artifacts\/provenance\.json \.release-artifacts-provenance\.json/)
+    assert.match(publish, /cp "\$RUNNER_TEMP"\/sealed\/provenance\.json \.release-artifacts-provenance\.json/)
     assert.match(publish, /test "\$\(ls \.release-artifacts\/\*\.tgz \| wc -l\)" -eq 20/)
+  })
+
+  test('a downloaded artifact never lands inside the checkout', () => {
+    // `path: workspace-artifacts` put twenty-five files in the working tree.
+    // Nothing ignores them, so `verify-provenance.mjs` counted them and
+    // refused the release with `worktree_dirty` — correctly: a dirty tree
+    // cannot honestly name the source of its own artifacts. The verify job
+    // never hit it because `.release-artifacts/` and its manifest are both in
+    // `.gitignore`.
+    const publish = job(DEEPWATCH, 'publish')
+    const download = publish.slice(publish.indexOf('download-artifact'))
+    const path = /path:\s*([^\n]+)/.exec(download)?.[1]?.trim() ?? ''
+    assert.match(path, /runner\.temp/,
+      'the download must go outside the checkout, or it dirties the tree')
+
+    // And the step that restores it proves the tree survived. Read from the
+    // steps rather than the file: the comment explaining this fix names
+    // `verify-provenance.mjs`, so a text search finds the prose before the run.
+    assert.match(publish, /status --porcelain=v1 --untracked-files=all/)
+    const steps = publish.split('\n').filter(line => !/^\s*#/.test(line)).join('\n')
+    assert.ok(steps.indexOf('--untracked-files=all') < steps.indexOf('verify-provenance.mjs'),
+      'the cleanliness check comes before the gate that depends on it')
   })
 
   test('the publishing npm is pinned, not whatever shipped this morning', () => {


### PR DESCRIPTION
The two things between the tag and a published release.

## The publish job dirtied its own checkout

Run [34076416359](https://github.com/oxbshw/watch-skill/actions/runs/34076416359) failed in **Publish to npm** at *"These are the bytes the verify job sealed"*; **Complete the GitHub Release** and the registry smoke were skipped behind it. Nothing was published.

`path: workspace-artifacts` put twenty-five files inside the working tree. Nothing ignores them, so `verify-provenance.mjs` — which refuses a tree that cannot honestly name the source of its own artifacts — counted them and rejected the release with `worktree_dirty`. The check was right; the download was in the wrong place. `.release-artifacts/` and its manifest are both gitignored, which is why the verify job never hit this.

The download now goes to `$RUNNER_TEMP`, and the restore step asserts the tree is still clean **before** the gate that depends on it.

## first-publish.mjs published through a captured pipe

npm's `otplease` (`lib/utils/auth.js`, confirmed in the **11.17.0** this repository resolves — not 11.19.0) opens its catch with:

```js
if (!process.stdin.isTTY || !process.stdout.isTTY) { throw err }
```

That runs *before* it checks whether the error is an `EOTP` carrying the `authUrl` and `doneUrl` that drive the browser flow. Publishing through `spawnSync` with captured stdio therefore fails with a bare *"this operation requires a one-time password"* for an account that can publish perfectly well, and never offers the challenge.

The upload now runs with `stdio: 'inherit'` so npm owns the terminal. **No one-time password is read, printed, stored, or accepted as an argument** — asserted by a test. The read-only probes stay captured and sanitized, because their answers are inspected and can carry credential-shaped text.

Inheriting a pipe is still a pipe, so the script refuses up front when there is no TTY and explains the cause, instead of letting the operator discover it on package one and go hunting for a broken credential.

## Checks

`npm run check` green locally: 2418 pass, 5 skipped, 0 fail.