### PR TITLE
fix(surface,receipt): findings from the real-model acceptance run

### DIFF
--- a/.github/workflows/post-publish.yml
+++ b/.github/workflows/post-publish.yml
@@ -152,7 +152,37 @@ jobs:
           spec='${{ needs.version.outputs.spec }}'
           requested='${{ needs.version.outputs.version }}'
           echo "resolving $spec"
-          reported=$(uvx --from "$spec" watch-skill --version)
+
+          # Retry only what a second attempt could plausibly fix: a CDN that
+          # is serving the metadata and not yet the file, a dropped
+          # connection, a 429. A resolution failure, a hash mismatch or a
+          # wheel that will not build says the same thing next time, and
+          # retrying it buries the sentence that explained it under three more
+          # minutes. The version assertion below stays outside the loop — a
+          # package that installs and then reports the wrong version is a
+          # finding, not a flake.
+          attempt=0
+          delay=5
+          until reported=$(uvx --from "$spec" watch-skill --version 2>uvx-err.log); do
+            attempt=$((attempt + 1))
+            case "$(cat uvx-err.log)" in
+              *"hash mismatch"*|*"Failed to build"*|*"No solution found"*|*401*|*403*)
+                echo "::error::uvx failed for a reason a retry cannot fix:"
+                cat uvx-err.log
+                exit 1
+                ;;
+            esac
+            if [ "$attempt" -ge 4 ]; then
+              echo "::error::uvx --from $spec failed ${attempt} times over 35s:"
+              cat uvx-err.log
+              exit 1
+            fi
+            echo "attempt ${attempt} failed; retrying in ${delay}s"
+            tail -n 20 uvx-err.log
+            sleep "$delay"
+            delay=$((delay * 2))
+          done
+
           echo "reported: $reported"
           test -n "$reported"
           if [ -n "$requested" ]; then

--- a/.github/workflows/release-deepwatch.yml
+++ b/.github/workflows/release-deepwatch.yml
@@ -439,7 +439,37 @@ jobs:
             sleep 10
           done
 
-          reported=$(npx --yes "@deepwatch/cli@${version}" --version)
+          # Retry only what a second attempt could plausibly fix.
+          #
+          # A replica that has not caught up, a dropped connection, a 429 or a
+          # 5xx are worth another go. An authentication failure or an integrity
+          # mismatch are not: they say the same thing next time, and retrying
+          # them turns a red check into a slow red check while burying the
+          # sentence that explained it. The version assertion is outside the
+          # loop for the same reason — a CLI that installs and then reports the
+          # wrong version is a finding, not a flake.
+          attempt=0
+          delay=5
+          until reported=$(npx --yes "@deepwatch/cli@${version}" --version 2>npx-err.log); do
+            attempt=$((attempt + 1))
+            case "$(cat npx-err.log)" in
+              *EINTEGRITY*|*ENEEDAUTH*|*E401*|*E403*|*EPERM*)
+                echo "::error::npx failed for a reason a retry cannot fix:"
+                cat npx-err.log
+                exit 1
+                ;;
+            esac
+            if [ "$attempt" -ge 4 ]; then
+              echo "::error::npx @deepwatch/cli@${version} failed ${attempt} times over 35s:"
+              cat npx-err.log
+              exit 1
+            fi
+            echo "attempt ${attempt} failed; retrying in ${delay}s"
+            tail -n 20 npx-err.log
+            sleep "${delay}"
+            delay=$((delay * 2))
+          done
+
           echo "reported: ${reported}"
           test "${reported}" = "${version}"
 

--- a/release-surface-fixtures.json
+++ b/release-surface-fixtures.json
@@ -39,5 +39,33 @@
       "deepwatch-workspace/thing",
       "the DeepWatch Workspace"
     ]
+  },
+  "$exemptions": {
+    "phantom-repository": {
+      "$comment": [
+        "Lines as they appear inside a file exempted from phantom-repository.",
+        "`clean` must produce no finding; `reported` must produce one. Both real",
+        "scanners run these against the actual exempted file, because the point",
+        "is the exemption path, not the pattern.",
+        "",
+        "The whitespace cases exist because a `contains` exemption matched the",
+        "exact string only: a row written with two spaces or a tab was still",
+        "rejected. The same-line case exists because that exemption skipped the",
+        "whole line, hiding a genuine stale reference sitting beside the row."
+      ],
+      "clean": [
+        "- id: watch-workspace",
+        "- id:  watch-workspace",
+        "- id:\twatch-workspace",
+        "  id: watch-workspace",
+        "    - id: watch-workspace"
+      ],
+      "reported": [
+        "Clone watch-workspace and run pnpm install.",
+        "repository: watch-workspace",
+        "oxbshw/watch-workspace",
+        "- id: watch-workspace  <!-- clone watch-workspace to get started -->"
+      ]
+    }
   }
 }

--- a/release-surface-fixtures.json
+++ b/release-surface-fixtures.json
@@ -1,0 +1,43 @@
+{
+  "$comment": [
+    "Positive and negative cases for release-surface rules, read by BOTH engines:",
+    "workspace/tests/release-surface.test.mjs (Node) and tests/test_release_surface.py",
+    "(Python). One file, so a case cannot be fixed in one engine and left broken in",
+    "the other -- which is exactly how `phantom-repository` shipped a pattern that",
+    "matched nothing on the Python side.",
+    "",
+    "`catches` must fire. `allows` must not. Add a case whenever a rule is",
+    "narrowed: a narrowing without a case is a rule nobody re-checked."
+  ],
+  "phantom-repository": {
+    "why": [
+      "The rule names a repository that does not exist. It was narrowed twice and",
+      "broke both times: first with an unanchored pattern that matched inside",
+      "`deepwatch-workspace`, then with a lookbehind that Python's shared table",
+      "forbids and that silently missed Markdown and `repository:` forms while",
+      "wrongly sparing a row id written with two spaces.",
+      "",
+      "The pattern is now the simple bounded name. The profile row that mounts",
+      "@deepwatch/dsh-workspace is genuinely called `watch-workspace`, and no",
+      "pattern can tell it from a repository reference by surrounding characters",
+      "alone -- so those two files carry a narrow, per-file exemption instead."
+    ],
+    "catches": [
+      "Clone watch-workspace and run pnpm install.",
+      "Clone `watch-workspace` and run pnpm install.",
+      "repository: watch-workspace",
+      "oxbshw/watch-workspace",
+      "see watch-workspace.",
+      "clone the watch-workspace repository",
+      "watch-workspace at the start of a line",
+      "  watch-workspace indented"
+    ],
+    "allows": [
+      "Clone watch-skill and run pnpm install in workspace/.",
+      "#the-deepwatch-workspace",
+      "@deepwatch/dsh-workspace",
+      "deepwatch-workspace/thing",
+      "the DeepWatch Workspace"
+    ]
+  }
+}

--- a/release-surface-rules.json
+++ b/release-surface-rules.json
@@ -124,12 +124,14 @@
     {
       "file": "workspace/docs/package-notes.json",
       "rule": "phantom-repository",
-      "why": "carries the `watch-workspace` profile row that mounts @deepwatch/dsh-workspace, which is an identifier in somebody’s YAML rather than a repository anybody could clone"
+      "why": "the `watch-workspace` profile row that mounts @deepwatch/dsh-workspace is an identifier in somebody’s YAML, not a repository anybody could clone. Scoped to lines holding that row: any other stale reference in this file still fires.",
+      "contains": "id: watch-workspace"
     },
     {
       "file": "workspace/packages/watch/workspace/README.md",
       "rule": "phantom-repository",
-      "why": "carries the `watch-workspace` profile row that mounts @deepwatch/dsh-workspace, which is an identifier in somebody’s YAML rather than a repository anybody could clone"
+      "why": "the `watch-workspace` profile row that mounts @deepwatch/dsh-workspace is an identifier in somebody’s YAML, not a repository anybody could clone. Scoped to lines holding that row: any other stale reference in this file still fires.",
+      "contains": "id: watch-workspace"
     }
   ]
 }

--- a/release-surface-rules.json
+++ b/release-surface-rules.json
@@ -132,6 +132,12 @@
       "rule": "phantom-repository",
       "why": "the `watch-workspace` profile row that mounts @deepwatch/dsh-workspace is an identifier in somebody’s YAML, not a repository anybody could clone. Scoped to the occurrence that follows the row key, so another reference on the same line still fires.",
       "precededBy": "(?:^|[\\s-])id:[\\t ]*$"
+    },
+    {
+      "file": "deepwatch-dsh-workspace:README.md",
+      "rule": "phantom-repository",
+      "precededBy": "(?:^|[\\s-])id:[\\t ]*$",
+      "why": "the packed copy of the same README, keyed by package with the version stripped. Same row, same scoping: only the occurrence following the row key is excused."
     }
   ]
 }

--- a/release-surface-rules.json
+++ b/release-surface-rules.json
@@ -42,8 +42,8 @@
     },
     {
       "id": "phantom-repository",
-      "pattern": "(?:^\\s*|[^:]\\s|/)watch-workspace\\b",
-      "why": "names a repository that does not exist; both halves live in oxbshw/watch-skill. A profile row (`id: watch-workspace`) is the plugin that mounts @deepwatch/dsh-workspace, not a repository, so it does not fire."
+      "pattern": "\\bwatch-workspace\\b",
+      "why": "names a repository that does not exist; both halves live in oxbshw/watch-skill"
     },
     {
       "id": "personal-path",
@@ -120,6 +120,16 @@
       "file": "workspace/docs/releasing.md",
       "rule": "unfinished-claim",
       "why": "documents that the first npm publication has not happened, which is a fact about the release rather than an unfinished page"
+    },
+    {
+      "file": "workspace/docs/package-notes.json",
+      "rule": "phantom-repository",
+      "why": "carries the `watch-workspace` profile row that mounts @deepwatch/dsh-workspace, which is an identifier in somebody’s YAML rather than a repository anybody could clone"
+    },
+    {
+      "file": "workspace/packages/watch/workspace/README.md",
+      "rule": "phantom-repository",
+      "why": "carries the `watch-workspace` profile row that mounts @deepwatch/dsh-workspace, which is an identifier in somebody’s YAML rather than a repository anybody could clone"
     }
   ]
 }

--- a/release-surface-rules.json
+++ b/release-surface-rules.json
@@ -124,14 +124,14 @@
     {
       "file": "workspace/docs/package-notes.json",
       "rule": "phantom-repository",
-      "why": "the `watch-workspace` profile row that mounts @deepwatch/dsh-workspace is an identifier in somebody’s YAML, not a repository anybody could clone. Scoped to lines holding that row: any other stale reference in this file still fires.",
-      "contains": "id: watch-workspace"
+      "why": "the `watch-workspace` profile row that mounts @deepwatch/dsh-workspace is an identifier in somebody’s YAML, not a repository anybody could clone. Scoped to the occurrence that follows the row key, so another reference on the same line still fires.",
+      "precededBy": "(?:^|[\\s-])id:[\\t ]*$"
     },
     {
       "file": "workspace/packages/watch/workspace/README.md",
       "rule": "phantom-repository",
-      "why": "the `watch-workspace` profile row that mounts @deepwatch/dsh-workspace is an identifier in somebody’s YAML, not a repository anybody could clone. Scoped to lines holding that row: any other stale reference in this file still fires.",
-      "contains": "id: watch-workspace"
+      "why": "the `watch-workspace` profile row that mounts @deepwatch/dsh-workspace is an identifier in somebody’s YAML, not a repository anybody could clone. Scoped to the occurrence that follows the row key, so another reference on the same line still fires.",
+      "precededBy": "(?:^|[\\s-])id:[\\t ]*$"
     }
   ]
 }

--- a/src/watch_skill/loop/capture.py
+++ b/src/watch_skill/loop/capture.py
@@ -15,7 +15,13 @@ from typing import Any
 
 from watch_skill.errors import LoopError
 from watch_skill.health.binaries import require_binary
-from watch_skill.perceive.cues import Cue, clear_sidecar, to_media_timeline, write_sidecar
+from watch_skill.perceive.cues import (
+    Cue,
+    clear_sidecar,
+    measure_offset,
+    to_media_timeline,
+    write_sidecar,
+)
 
 DEFAULT_VIEWPORT = {"width": 1280, "height": 720}
 MOBILE_VIEWPORT = {"width": 390, "height": 844}
@@ -180,6 +186,7 @@ def capture_url(
     out_dir.mkdir(parents=True, exist_ok=True)
     size = viewport or DEFAULT_VIEWPORT
     marks: list[tuple[float, str]] = []
+    first_change: float | None = None
     with sync_playwright() as p:
         browser = _launch_browser(p)
         context = browser.new_context(
@@ -203,13 +210,23 @@ def capture_url(
                     # one that shows the result is the one worth keeping, so
                     # the capture writes down when that state was on screen.
                     watching = step.get("action") != "wait"
+                    began = time.monotonic() - origin
                     before = _rendered_text(page) if watching else None
                     _run_script_step(page, step)
                     if watching:
                         appeared, settled = _observe(page, before, origin)
+                        # The first time this session saw the page change is
+                        # the one event both clocks witnessed; it is what the
+                        # recording is aligned against afterwards.
+                        if first_change is None and settled > appeared:
+                            first_change = appeared
                     else:
-                        settled = time.monotonic() - origin
-                        appeared = settled
+                        # A wait produces no new state. What it shows is
+                        # whatever was already there, for the whole of its
+                        # duration -- and its far edge is the instant the next
+                        # step runs, which is the one moment in that window
+                        # that may catch a half-applied interaction.
+                        appeared, settled = began, time.monotonic() - origin
                     marks.append(((appeared + settled) / 2, _step_label(step)))
             else:
                 page.wait_for_timeout(int(duration_seconds * 500))
@@ -239,9 +256,24 @@ def capture_url(
         from watch_skill.perceive import probe  # noqa: PLC0415 — heavy import
 
         media_duration = probe(dest).duration_seconds
+        # Where this session's clock sits relative to the recording's, measured
+        # against the recording rather than guessed from its length. The two
+        # differ by a fraction of a second that the durations do not reveal:
+        # a screencast starts a little after the page does, and then holds its
+        # last frame past the end of the session, so a file with a leading gap
+        # comes out *longer* than the session that produced it.
+        offset = 0.0
+        if first_change is not None:
+            measured = measure_offset(
+                dest,
+                changed_at=first_change - (_SETTLE_POLL_MS / 2000),
+                media_duration=media_duration,
+            )
+            if measured is not None:
+                offset = measured
         cue_seconds = to_media_timeline(
             [moment for moment, _label in marks],
-            wall_span=wall_span,
+            offset=offset,
             media_duration=media_duration,
         )
         # A sidecar, because `watch-skill watch <file>` is a separate
@@ -252,7 +284,11 @@ def capture_url(
             dest,
             [Cue(seconds=t, label=label)
              for t, (_moment, label) in zip(cue_seconds, marks, strict=True)],
-            timeline={"wall_span": wall_span, "media_duration": media_duration},
+            timeline={
+                "wall_span": wall_span,
+                "media_duration": media_duration,
+                "offset": offset,
+            },
         )
     return CaptureResult(
         video_path=dest, kind="url", target=url,

--- a/src/watch_skill/loop/capture.py
+++ b/src/watch_skill/loop/capture.py
@@ -6,7 +6,6 @@ machine does not need the ~350 MB bundled Chromium download.
 """
 from __future__ import annotations
 
-import json
 import subprocess
 import sys
 import time
@@ -16,10 +15,21 @@ from typing import Any
 
 from watch_skill.errors import LoopError
 from watch_skill.health.binaries import require_binary
+from watch_skill.perceive.cues import Cue, clear_sidecar, to_media_timeline, write_sidecar
 
 DEFAULT_VIEWPORT = {"width": 1280, "height": 720}
 MOBILE_VIEWPORT = {"width": 390, "height": 844}
 _BROWSER_CHANNELS = ("msedge", "chrome", None)  # None = bundled chromium
+
+#: How a step's effect is observed before its moment is written down.
+#:
+#: Bounded on purpose, in both directions. A page with a clock or a spinner on
+#: it never stops changing, and a click that does nothing never starts -- so
+#: each phase has its own ceiling and a step costs at most two seconds of
+#: watching whatever the page does.
+_SETTLE_POLL_MS = 100
+_SETTLE_CHANGE_POLLS = 10
+_SETTLE_STABLE_POLLS = 2
 
 
 @dataclass
@@ -56,6 +66,76 @@ def _run_script_step(page: Any, step: dict[str, Any]) -> None:
             code="loop.bad_script",
             fix="use actions: goto, click, fill, press, scroll, wait",
         )
+
+
+def _rendered_text(page: Any) -> str | None:
+    """What the page currently says, or None if it is mid-navigation."""
+    try:
+        return str(page.evaluate(
+            "() => document.body ? document.body.innerText : ''"))
+    except Exception:  # a navigation swapped the document out from under us
+        return None
+
+
+def _observe(page: Any, before: str | None, origin: float) -> tuple[float, float]:
+    """Watch until the page has changed and then stopped changing again.
+
+    A moment recorded the instant ``page.fill`` returns names when the *input*
+    changed, not when the page finished changing because of it. A total that a
+    listener recomputes on a later tick is still the old total in that frame,
+    so the cue would pin the state before the interaction rather than after it.
+
+    Waiting for stability alone is not enough either, and the difference is not
+    academic: a page that repaints 350 ms after the edit is perfectly stable
+    for the 200 ms in between, so a settle that only asks "has it stopped
+    moving" returns before anything happened. So this waits for the change
+    first, and for it to stop second.
+
+    Returns the window, in seconds from ``origin``, over which the new state
+    was actually observed on the page -- first seen, and last seen unchanged.
+    Pinning inside an observed window rather than at its edge is what absorbs
+    the residual error in mapping onto the recording's own timeline.
+    """
+    appeared: float | None = None
+    for _ in range(_SETTLE_CHANGE_POLLS):
+        current = _rendered_text(page)
+        if current is None:
+            break
+        if before is None or current != before:
+            appeared = time.monotonic() - origin
+            before = current
+            break
+        page.wait_for_timeout(_SETTLE_POLL_MS)
+    if appeared is None:
+        # Nothing this step did was visible -- a scroll on a short page, a
+        # click on a dead control. There is no transition to sit inside.
+        now = time.monotonic() - origin
+        return now, now
+
+    previous = before
+    stable = 0
+    for _ in range(_SETTLE_CHANGE_POLLS):
+        page.wait_for_timeout(_SETTLE_POLL_MS)
+        current = _rendered_text(page)
+        now = time.monotonic() - origin
+        if current is None:
+            return appeared, now
+        if current == previous:
+            stable += 1
+            if stable >= _SETTLE_STABLE_POLLS:
+                return appeared, now
+        else:
+            appeared = now  # still moving; the state that lasts is a later one
+            stable = 0
+            previous = current
+    return appeared, time.monotonic() - origin
+
+
+def _step_label(step: dict[str, Any]) -> str:
+    """What a cue is a cue for, in the words of the script that caused it."""
+    action = str(step.get("action", "?"))
+    subject = step.get("selector") or step.get("key") or step.get("url")
+    return f"{action} {subject}" if subject else action
 
 
 def _launch_browser(playwright: Any):
@@ -99,31 +179,44 @@ def capture_url(
 
     out_dir.mkdir(parents=True, exist_ok=True)
     size = viewport or DEFAULT_VIEWPORT
-    cue_times: list[float] = []
+    marks: list[tuple[float, str]] = []
     with sync_playwright() as p:
         browser = _launch_browser(p)
         context = browser.new_context(
             viewport=size, record_video_dir=str(out_dir), record_video_size=size
         )
         page = context.new_page()
+        # The recording starts with the page, not with the first navigation.
+        # `page.goto` takes as long as the site takes -- seconds against a cold
+        # server -- and a clock started after it names every later moment that
+        # much too early, which points frame selection at the blank page the
+        # app had not rendered into yet.
+        origin = time.monotonic()
         try:
             page.goto(url, wait_until="load")
-            started = time.monotonic()
             if script:
                 for step in script:
-                    _run_script_step(page, step)
                     # An interaction is the moment the page became something
-                    # new. Recorded so frame selection can pin it: the frames
-                    # either side of a `fill` are perceptually near-identical
-                    # -- a checkout page where three numbers change hashes
-                    # within the near-duplicate threshold -- and the one that
-                    # shows the result is exactly the one worth keeping.
-                    cue_times.append(round(time.monotonic() - started, 3))
+                    # new, and the frames either side of it are perceptually
+                    # near-identical -- a checkout page where three numbers
+                    # change hashes inside the near-duplicate threshold. The
+                    # one that shows the result is the one worth keeping, so
+                    # the capture writes down when that state was on screen.
+                    watching = step.get("action") != "wait"
+                    before = _rendered_text(page) if watching else None
+                    _run_script_step(page, step)
+                    if watching:
+                        appeared, settled = _observe(page, before, origin)
+                    else:
+                        settled = time.monotonic() - origin
+                        appeared = settled
+                    marks.append(((appeared + settled) / 2, _step_label(step)))
             else:
                 page.wait_for_timeout(int(duration_seconds * 500))
                 page.mouse.wheel(0, 800)
                 page.wait_for_timeout(int(duration_seconds * 500))
         finally:
+            wall_span = time.monotonic() - origin
             video = page.video
             context.close()  # flushes the recording
             raw_path = Path(video.path()) if video else None
@@ -137,17 +230,33 @@ def capture_url(
         )
     dest = out_dir / "capture.webm"
     raw_path.replace(dest)
-    # A sidecar, because `watch-skill watch <file>` is a separate invocation
-    # that receives only the path. Without it the interaction moments are lost
-    # between the two commands, and frame selection has nothing to pin.
-    if cue_times:
-        cue_file = dest.with_suffix(".cues.json")
-        cue_file.write_text(
-            json.dumps({"cues": cue_times}, indent=2) + "\n", encoding="utf-8"
+    # Whatever an earlier recording into this directory left behind describes
+    # a file that no longer exists.
+    clear_sidecar(dest)
+
+    cue_seconds: list[float] = []
+    if marks:
+        from watch_skill.perceive import probe  # noqa: PLC0415 — heavy import
+
+        media_duration = probe(dest).duration_seconds
+        cue_seconds = to_media_timeline(
+            [moment for moment, _label in marks],
+            wall_span=wall_span,
+            media_duration=media_duration,
+        )
+        # A sidecar, because `watch-skill watch <file>` is a separate
+        # invocation that is handed only a path. Without it the interaction
+        # moments are lost between the two commands and frame selection has
+        # nothing to pin.
+        write_sidecar(
+            dest,
+            [Cue(seconds=t, label=label)
+             for t, (_moment, label) in zip(cue_seconds, marks, strict=True)],
+            timeline={"wall_span": wall_span, "media_duration": media_duration},
         )
     return CaptureResult(
         video_path=dest, kind="url", target=url,
-        meta={"viewport": size, "scripted": bool(script), "cues": cue_times},
+        meta={"viewport": size, "scripted": bool(script), "cues": cue_seconds},
     )
 
 
@@ -191,6 +300,7 @@ def capture_screen(
             fix="check the window title exists (exact match) and the session is not locked",
             details={"stderr": result.stderr[-800:], "input": grab_input},
         )
+    clear_sidecar(dest)  # a scripted URL capture may have written here first
     return CaptureResult(
         video_path=dest, kind="window" if window_title else "screen",
         target=window_title or "desktop",
@@ -212,6 +322,7 @@ def capture_file(path: str | Path, out_dir: Path) -> CaptureResult:
     import shutil
 
     shutil.copy2(source, dest)
+    clear_sidecar(dest)  # a scripted URL capture may have written here first
     return CaptureResult(video_path=dest, kind="file", target=str(source), meta={})
 
 

--- a/src/watch_skill/loop/capture.py
+++ b/src/watch_skill/loop/capture.py
@@ -6,6 +6,7 @@ machine does not need the ~350 MB bundled Chromium download.
 """
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
 import time
@@ -98,6 +99,7 @@ def capture_url(
 
     out_dir.mkdir(parents=True, exist_ok=True)
     size = viewport or DEFAULT_VIEWPORT
+    cue_times: list[float] = []
     with sync_playwright() as p:
         browser = _launch_browser(p)
         context = browser.new_context(
@@ -106,9 +108,17 @@ def capture_url(
         page = context.new_page()
         try:
             page.goto(url, wait_until="load")
+            started = time.monotonic()
             if script:
                 for step in script:
                     _run_script_step(page, step)
+                    # An interaction is the moment the page became something
+                    # new. Recorded so frame selection can pin it: the frames
+                    # either side of a `fill` are perceptually near-identical
+                    # -- a checkout page where three numbers change hashes
+                    # within the near-duplicate threshold -- and the one that
+                    # shows the result is exactly the one worth keeping.
+                    cue_times.append(round(time.monotonic() - started, 3))
             else:
                 page.wait_for_timeout(int(duration_seconds * 500))
                 page.mouse.wheel(0, 800)
@@ -127,9 +137,17 @@ def capture_url(
         )
     dest = out_dir / "capture.webm"
     raw_path.replace(dest)
+    # A sidecar, because `watch-skill watch <file>` is a separate invocation
+    # that receives only the path. Without it the interaction moments are lost
+    # between the two commands, and frame selection has nothing to pin.
+    if cue_times:
+        cue_file = dest.with_suffix(".cues.json")
+        cue_file.write_text(
+            json.dumps({"cues": cue_times}, indent=2) + "\n", encoding="utf-8"
+        )
     return CaptureResult(
         video_path=dest, kind="url", target=url,
-        meta={"viewport": size, "scripted": bool(script)},
+        meta={"viewport": size, "scripted": bool(script), "cues": cue_times},
     )
 
 

--- a/src/watch_skill/perceive/cues.py
+++ b/src/watch_skill/perceive/cues.py
@@ -1,0 +1,339 @@
+"""Interaction cues: the moments a recording was made in order to show.
+
+A scripted capture knows something no frame sampler can work out afterwards.
+When a script fills a quantity box and the page recomputes a total, the frames
+either side of that edit are perceptually near-identical -- three numbers move
+in a layout that is otherwise the same -- and near-duplicate selection drops
+the one that carries the change. The capture layer knows exactly when it acted,
+so it writes those moments down.
+
+`watch-skill capture` and `watch-skill watch` are two invocations, and the
+second is handed only a path. The moments travel between them in a sidecar
+beside the recording: ``capture.webm`` -> ``capture.cues.json``.
+
+Three things make a sidecar trustworthy enough to act on automatically, and
+this module is where all three live so that every ingestion path gets them:
+
+* **it is bound to the recording it describes.** A sidecar names the file's
+  size and digest. A capture that overwrote the video and left the old sidecar
+  behind is a mismatch, not a hint, and is refused.
+* **its numbers are on the recording's own timeline.** The writer converts
+  from its wall clock before storing them; see :func:`to_media_timeline`.
+* **nothing in it is taken on trust.** Shape, types, finiteness, sign, bounds
+  and size are all checked, because the file sits in a directory a user can
+  write to.
+"""
+from __future__ import annotations
+
+import json
+import math
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from watch_skill.errors import WatchSkillError
+from watch_skill.identity import digest_file
+
+#: The extension a recording's cues live under, beside the recording.
+SIDECAR_SUFFIX = ".cues.json"
+
+#: Bumped only for a change a previous reader could not understand.
+SCHEMA_VERSION = 1
+
+#: A sidecar is a short list of numbers. Anything larger is not one, and
+#: reading it is a cost this pipeline should not pay to find that out.
+MAX_SIDECAR_BYTES = 256 * 1024
+
+#: Each cue is a pinned frame reserved against the frame budget. Past a few
+#: hundred there is no budget left for anything the sampler would have chosen.
+MAX_CUES = 512
+
+#: A recording's duration is measured from its container and a cue is derived
+#: from a clock; the last cue of a session lands within a frame or two of the
+#: end. Inside this, a cue past the end is trimmed to the end rather than
+#: refused; beyond it, the sidecar is describing a different recording.
+BOUNDS_TOLERANCE_SECONDS = 0.5
+
+
+class CueError(WatchSkillError):
+    """A cue sidecar exists and cannot be believed."""
+
+    default_code = "cues.invalid"
+
+
+@dataclass(frozen=True)
+class Cue:
+    """One moment on a recording's own timeline, and what happened at it."""
+
+    seconds: float
+    label: str | None = None
+
+    def to_json(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {"seconds": round(self.seconds, 3)}
+        if self.label:
+            payload["label"] = self.label
+        return payload
+
+
+def sidecar_path_for(video_path: str | Path) -> Path:
+    """Where the cues for ``video_path`` live."""
+    return Path(video_path).with_suffix(SIDECAR_SUFFIX)
+
+
+def clear_sidecar(video_path: str | Path) -> None:
+    """Remove any cues left beside ``video_path`` by an earlier recording.
+
+    Capture writes to a fixed name inside the output directory, so a second
+    run overwrites the video. Without this, an unscripted re-record inherits
+    the previous run's interaction moments: the file is bound by digest and
+    would be refused, but a refusal a user has to read is a worse outcome than
+    the stale file never existing.
+    """
+    sidecar_path_for(video_path).unlink(missing_ok=True)
+
+
+def to_media_timeline(
+    wall_seconds: list[float], *, wall_span: float, media_duration: float
+) -> list[float]:
+    """Move wall-clock moments onto the recording's own timeline.
+
+    The two clocks share an origin -- the recording starts with the page that
+    is being recorded -- but not a length. A screencast is a stream of frames
+    the browser emits once it is ready to emit them, so the file that lands on
+    disk is normally a little shorter than the session that produced it, and
+    the missing part is at the front.
+
+    So the correction is an offset and not a rate: everything is early by the
+    same amount, the amount being whatever the recording turned out to be
+    missing. A moment that lands before the start of the recording is clamped
+    to it rather than dropped, because the alternative is losing the cue for
+    the first interaction on a session that started slowly.
+
+    The residual error is why the writer pins the middle of a state's visible
+    window rather than the instant it appeared; see
+    :func:`watch_skill.loop.capture.capture_url`.
+    """
+    # Length-preserving: the caller pairs the result with the labels it
+    # collected, so a value that maps to nothing has to map to *something*.
+    # A moment that is not a number is not one, and the start of the recording
+    # is the least wrong place for a frame nobody can locate.
+    if media_duration <= 0 or not math.isfinite(media_duration):
+        return [
+            round(max(0.0, value), 3) if math.isfinite(value) else 0.0
+            for value in wall_seconds
+        ]
+    drift = max(0.0, wall_span - media_duration)
+    return [
+        round(min(max(value - drift, 0.0), media_duration), 3)
+        if math.isfinite(value) else 0.0
+        for value in wall_seconds
+    ]
+
+
+def write_sidecar(
+    video_path: str | Path,
+    cues: list[Cue],
+    *,
+    timeline: dict[str, float] | None = None,
+) -> Path:
+    """Write ``cues`` beside ``video_path``, bound to the recording's bytes."""
+    video = Path(video_path)
+    destination = sidecar_path_for(video)
+    payload: dict[str, Any] = {
+        "version": SCHEMA_VERSION,
+        "recording": {
+            "name": video.name,
+            "bytes": video.stat().st_size,
+            "sha256": digest_file(video),
+        },
+        "cues": [cue.to_json() for cue in cues],
+    }
+    if timeline is not None:
+        payload["timeline"] = {k: round(v, 3) for k, v in timeline.items()}
+    destination.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    return destination
+
+
+def _fail(message: str, *, code: str, fix: str, path: Path) -> CueError:
+    return CueError(message, code=code, fix=fix, details={"sidecar": str(path)})
+
+
+def _seconds_from(entry: Any, index: int, path: Path) -> float:
+    """One cue's timestamp, or a refusal naming which cue was wrong."""
+    value = entry.get("seconds") if isinstance(entry, dict) else entry
+    # `bool` is an `int`, and `True` would otherwise pin a frame at one second.
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise _fail(
+            f"cue {index} is not a number: {value!r}",
+            code="cues.bad_timestamp",
+            fix="each cue is a number of seconds, or an object with a numeric "
+            '"seconds" field',
+            path=path,
+        )
+    seconds = float(value)
+    if not math.isfinite(seconds):
+        raise _fail(
+            f"cue {index} is {seconds}, which is not a moment in a recording",
+            code="cues.bad_timestamp",
+            fix="remove the cue, or re-record; NaN and Infinity are not times",
+            path=path,
+        )
+    if seconds < 0:
+        raise _fail(
+            f"cue {index} is {seconds:g}s, before the recording starts",
+            code="cues.bad_timestamp",
+            fix="cue times are measured forward from the start of the recording",
+            path=path,
+        )
+    return seconds
+
+
+def _check_binding(payload: dict[str, Any], video: Path, path: Path) -> None:
+    """Refuse a sidecar that describes some other recording.
+
+    Capture writes to a fixed file name, so the second recording into an
+    output directory replaces the first. A sidecar that survived that would
+    pin frames from one session onto another and nothing downstream could
+    tell -- the timestamps are in range and the frames come out fine, they
+    are simply of the wrong moments.
+    """
+    recording = payload.get("recording")
+    if recording is None:
+        if "version" in payload:
+            raise _fail(
+                "the sidecar declares a version and names no recording",
+                code="cues.unbound",
+                fix="re-record with `watch-skill capture`, which writes the "
+                "recording's size and digest, or delete the sidecar",
+                path=path,
+            )
+        # A hand-written override. Nothing claims it came from a capture, so
+        # there is no stale-file scenario to protect against.
+        return
+    if not isinstance(recording, dict):
+        raise _fail(
+            f'"recording" is {type(recording).__name__}, not an object',
+            code="cues.bad_schema",
+            fix="delete the sidecar and re-record with `watch-skill capture`",
+            path=path,
+        )
+    size = video.stat().st_size
+    if recording.get("bytes") != size:
+        raise _fail(
+            f"the sidecar describes a {recording.get('bytes')}-byte recording "
+            f"and {video.name} is {size} bytes",
+            code="cues.stale",
+            fix=f"delete {path.name} — it belongs to an earlier recording that "
+            "was overwritten; re-run the capture to regenerate it",
+            path=path,
+        )
+    if recording.get("sha256") != digest_file(video):
+        raise _fail(
+            f"{video.name} is not the recording this sidecar was written for",
+            code="cues.stale",
+            fix=f"delete {path.name} — it belongs to a different recording; "
+            "re-run the capture to regenerate it",
+            path=path,
+        )
+
+
+def read_sidecar(
+    video_path: str | Path, *, duration_seconds: float | None = None
+) -> list[float] | None:
+    """The cues recorded beside ``video_path``, or ``None`` if there are none.
+
+    Raises :class:`CueError` when a sidecar is there and cannot be believed,
+    so a caller can report it rather than silently watching the video as if
+    the interactions had never been recorded.
+    """
+    video = Path(video_path)
+    path = sidecar_path_for(video)
+    if not path.is_file() or not video.is_file():
+        return None
+
+    size = path.stat().st_size
+    if size > MAX_SIDECAR_BYTES:
+        raise _fail(
+            f"{path.name} is {size} bytes; a cue sidecar is a short list of numbers",
+            code="cues.too_large",
+            fix=f"delete {path.name}, or pass the moments you want with "
+            "--timestamps",
+            path=path,
+        )
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, ValueError) as exc:
+        raise _fail(
+            f"{path.name} is not readable JSON: {exc}",
+            code="cues.unreadable",
+            fix=f"delete {path.name} and re-run the capture that wrote it",
+            path=path,
+        ) from exc
+
+    # `[]` and `null` are the shapes a half-written file takes, and calling
+    # `.get` on either raises an AttributeError nobody upstream expects.
+    if not isinstance(payload, dict):
+        raise _fail(
+            f"{path.name} holds {type(payload).__name__}, not an object",
+            code="cues.bad_schema",
+            fix='a cue sidecar is `{"cues": [...]}`; delete this one and '
+            "re-run the capture",
+            path=path,
+        )
+    raw = payload.get("cues")
+    if raw is None:
+        return None
+    if not isinstance(raw, list):
+        raise _fail(
+            f'"cues" is {type(raw).__name__}, not a list',
+            code="cues.bad_schema",
+            fix='"cues" is a list of seconds; delete the sidecar and re-run '
+            "the capture",
+            path=path,
+        )
+    if not raw:
+        return None
+    if len(raw) > MAX_CUES:
+        raise _fail(
+            f"{len(raw)} cues; every one is a frame reserved against the budget",
+            code="cues.too_many",
+            fix=f"keep at most {MAX_CUES}, or select the moments you want with "
+            "--timestamps",
+            path=path,
+        )
+
+    _check_binding(payload, video, path)
+
+    seconds = [_seconds_from(entry, i, path) for i, entry in enumerate(raw)]
+    if duration_seconds is not None and duration_seconds > 0:
+        limit = duration_seconds + BOUNDS_TOLERANCE_SECONDS
+        beyond = [value for value in seconds if value > limit]
+        if beyond:
+            raise _fail(
+                f"cue at {beyond[0]:.3f}s is past the end of a "
+                f"{duration_seconds:.3f}s recording",
+                code="cues.out_of_bounds",
+                fix=f"delete {path.name} — it does not describe this "
+                "recording; re-run the capture to regenerate it",
+                path=path,
+            )
+        seconds = [min(value, duration_seconds) for value in seconds]
+    return seconds
+
+
+def discover_cues(
+    video_path: str | Path, duration_seconds: float | None = None
+) -> list[float] | None:
+    """Cues for ``video_path``, degrading loudly rather than raising.
+
+    Discovery is something the pipeline does on the caller's behalf, so a
+    broken sidecar must not fail a watch the caller did ask for. It does not
+    pass silently either: the reason is printed with its code and its fix, the
+    same way an unavailable OCR engine is.
+    """
+    try:
+        return read_sidecar(video_path, duration_seconds=duration_seconds)
+    except CueError as exc:
+        print(f"[watch-skill] ignoring interaction cues — {exc}", file=sys.stderr)
+        return None

--- a/src/watch_skill/perceive/cues.py
+++ b/src/watch_skill/perceive/cues.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import json
 import math
 import sys
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -93,42 +94,158 @@ def clear_sidecar(video_path: str | Path) -> None:
     sidecar_path_for(video_path).unlink(missing_ok=True)
 
 
+#: How finely the recording is sampled when looking for its first change.
+ALIGN_STEP_SECONDS = 0.08
+
+#: How far into a recording that search goes before giving up.
+ALIGN_SEARCH_SECONDS = 6.0
+
+#: Past this, an "alignment" is a coincidence rather than a measurement.
+ALIGN_LIMIT_SECONDS = 3.0
+
+#: How much a pixel has to move to count as having changed, out of 255, and
+#: what share of the frame has to move before the frame has.
+#:
+#: Pixels rather than a perceptual hash, and the reason is the same one cues
+#: exist for: a phash is built to ignore what matters here. Three numbers
+#: changing on a checkout page hash four apart against a near-duplicate
+#: threshold of six -- and a black frame and a white frame hash *one* apart,
+#: because a DCT hash normalises brightness away entirely.
+ALIGN_PIXEL_DELTA = 24
+ALIGN_CHANGED_SHARE = 0.0004
+
+
 def to_media_timeline(
-    wall_seconds: list[float], *, wall_span: float, media_duration: float
+    wall_seconds: list[float], *, offset: float, media_duration: float
 ) -> list[float]:
     """Move wall-clock moments onto the recording's own timeline.
 
-    The two clocks share an origin -- the recording starts with the page that
-    is being recorded -- but not a length. A screencast is a stream of frames
-    the browser emits once it is ready to emit them, so the file that lands on
-    disk is normally a little shorter than the session that produced it, and
-    the missing part is at the front.
+    The two clocks run at the same rate and start at different moments, and
+    the difference cannot be worked out from their lengths -- which is the
+    trap, because it looks as though it can. Measured on a local page: a
+    1.609 s session produced a 2.600 s recording, which reads like a file with
+    a second to spare at the end and no gap at the front. It had both. The
+    trailing second is a flush of held frames; the front was missing 0.28 s,
+    and every moment in that recording sat 0.28 s later in content than the
+    clock said.
 
-    So the correction is an offset and not a rate: everything is early by the
-    same amount, the amount being whatever the recording turned out to be
-    missing. A moment that lands before the start of the recording is clamped
-    to it rather than dropped, because the alternative is losing the cue for
-    the first interaction on a session that started slowly.
-
-    The residual error is why the writer pins the middle of a state's visible
-    window rather than the instant it appeared; see
-    :func:`watch_skill.loop.capture.capture_url`.
+    So the offset is measured against the recording rather than inferred from
+    it -- see :func:`measure_offset` -- and applied here. A moment that lands
+    outside the recording is clamped rather than dropped, because the caller
+    pairs this list with the labels it collected and the two have to stay the
+    same length.
     """
-    # Length-preserving: the caller pairs the result with the labels it
-    # collected, so a value that maps to nothing has to map to *something*.
-    # A moment that is not a number is not one, and the start of the recording
-    # is the least wrong place for a frame nobody can locate.
     if media_duration <= 0 or not math.isfinite(media_duration):
         return [
             round(max(0.0, value), 3) if math.isfinite(value) else 0.0
             for value in wall_seconds
         ]
-    drift = max(0.0, wall_span - media_duration)
+    shift = offset if math.isfinite(offset) else 0.0
     return [
-        round(min(max(value - drift, 0.0), media_duration), 3)
+        round(min(max(value + shift, 0.0), media_duration), 3)
         if math.isfinite(value) else 0.0
         for value in wall_seconds
     ]
+
+
+def measure_offset(
+    video_path: Path,
+    *,
+    changed_at: float,
+    media_duration: float,
+    search_seconds: float = ALIGN_SEARCH_SECONDS,
+) -> float | None:
+    """Where the capture's clock sits relative to the recording's own.
+
+    Both clocks saw one event: the first time the page changed. The capture
+    noticed it by polling and wrote down when; the recording contains it, and
+    this finds where. The difference is the offset, and it is a measurement
+    rather than an assumption about how a browser starts a screencast.
+
+    ``changed_at`` is when the capture *observed* the change, so it is late by
+    up to one poll interval; the search below is late by up to one sample. Both
+    are corrected to the middle of their own interval, which leaves a residual
+    of about a twentieth of a second in each direction -- comfortably inside
+    the window a cue is pinned in.
+
+    Returns ``None`` when there is nothing to align to: a recording that never
+    changes, a search that runs out, or a result too large to be a measurement
+    of anything.
+    """
+    from watch_skill.perceive import media  # noqa: PLC0415 — heavy
+
+    if media_duration <= 0 or not math.isfinite(changed_at):
+        return None
+    # Only the neighbourhood the answer can be in. A recording also changes
+    # when it starts -- the first paint moves most of the frame -- and that
+    # transition is not the one both clocks saw.
+    low = max(0.0, changed_at - ALIGN_LIMIT_SECONDS)
+    high = min(media_duration, changed_at + ALIGN_LIMIT_SECONDS,
+               low + search_seconds)
+    if high <= low:
+        return None
+
+    nearest: float | None = None
+    with tempfile.TemporaryDirectory(prefix="watch-skill-align-") as room:
+        out = Path(room)
+        previous: bytes | None = None
+        at = low
+        index = 0
+        while at <= high:
+            index += 1
+            # PNG, not JPEG: two identical frames re-encoded lossily differ by
+            # more than a page's worth of digits do, which puts the noise floor
+            # above the signal. Decoded losslessly, two identical frames are
+            # identical and the floor is zero.
+            frame = media.extract_frame_at(
+                video_path, at, out / f"s{index:04d}.png", width=320)
+            if frame is None:
+                break
+            sample = _pixels(frame)
+            if sample is None:
+                return None
+            if previous is not None and _differ(previous, sample):
+                # Both clocks are late by half of their own interval.
+                seen_at = at - ALIGN_STEP_SECONDS / 2
+                if nearest is None or abs(seen_at - changed_at) < abs(
+                    nearest - changed_at
+                ):
+                    nearest = seen_at
+            previous = sample
+            at += ALIGN_STEP_SECONDS
+
+    if nearest is None:
+        return None
+    offset = nearest - changed_at
+    return offset if abs(offset) <= ALIGN_LIMIT_SECONDS else None
+
+
+def _pixels(image_path: Path) -> bytes | None:
+    """One frame as greyscale levels, or None if Pillow is not installed."""
+    try:
+        from PIL import Image  # noqa: PLC0415
+    except ImportError:
+        return None
+    with Image.open(image_path) as img:
+        return img.convert("L").tobytes()
+
+
+def _differ(previous: bytes, sample: bytes) -> bool:
+    """Whether enough of the frame moved to be a change rather than nothing.
+
+    Measured on a checkout recording: identical frames move 0.000 of the
+    pixels, the quantity edit that rewrites three amounts moves 0.002, and the
+    page's first paint moves 0.016. The floor is genuinely zero, so the
+    threshold sits an order of magnitude below the smallest real signal rather
+    than being tuned against noise.
+    """
+    if len(previous) != len(sample):
+        return True
+    moved = sum(
+        1 for a, b in zip(previous, sample, strict=True)
+        if abs(a - b) > ALIGN_PIXEL_DELTA
+    )
+    return moved / len(previous) > ALIGN_CHANGED_SHARE
 
 
 def write_sidecar(

--- a/src/watch_skill/surfaces/cli/main.py
+++ b/src/watch_skill/surfaces/cli/main.py
@@ -174,6 +174,21 @@ def watch(
     cues = None
     if timestamps:
         cues = [t for t in (parse_time(tok) for tok in timestamps.split(",") if tok.strip()) if t is not None]
+    elif Path(source).is_file():
+        # A recording made by `watch-skill capture --script` leaves a sidecar
+        # naming the moment of each interaction. Those frames are the point of
+        # the recording and are the ones near-duplicate selection is most
+        # likely to drop: a page where three numbers change hashes within the
+        # threshold of the page before it. Pinning them is why the sidecar
+        # exists; a recording without one is unaffected.
+        sidecar = Path(source).with_suffix(".cues.json")
+        if sidecar.is_file():
+            try:
+                recorded = json.loads(sidecar.read_text(encoding="utf-8")).get("cues")
+            except (OSError, ValueError):
+                recorded = None
+            if isinstance(recorded, list) and recorded:
+                cues = [float(t) for t in recorded if isinstance(t, (int, float))]
     try:
         result = run_watch(
             source,

--- a/src/watch_skill/surfaces/cli/main.py
+++ b/src/watch_skill/surfaces/cli/main.py
@@ -171,24 +171,12 @@ def watch(
         elif max_frames is None:
             max_frames = presets[preset]
 
+    # Only what the caller typed. A recording that carries its own interaction
+    # moments is read by the engine, so every surface behaves the same way and
+    # this one stays the wrapper it is supposed to be.
     cues = None
     if timestamps:
         cues = [t for t in (parse_time(tok) for tok in timestamps.split(",") if tok.strip()) if t is not None]
-    elif Path(source).is_file():
-        # A recording made by `watch-skill capture --script` leaves a sidecar
-        # naming the moment of each interaction. Those frames are the point of
-        # the recording and are the ones near-duplicate selection is most
-        # likely to drop: a page where three numbers change hashes within the
-        # threshold of the page before it. Pinning them is why the sidecar
-        # exists; a recording without one is unaffected.
-        sidecar = Path(source).with_suffix(".cues.json")
-        if sidecar.is_file():
-            try:
-                recorded = json.loads(sidecar.read_text(encoding="utf-8")).get("cues")
-            except (OSError, ValueError):
-                recorded = None
-            if isinstance(recorded, list) and recorded:
-                cues = [float(t) for t in recorded if isinstance(t, (int, float))]
     try:
         result = run_watch(
             source,

--- a/src/watch_skill/watch.py
+++ b/src/watch_skill/watch.py
@@ -14,6 +14,7 @@ from watch_skill.acquire import AcquireResult, acquire, fetch_captions_only
 from watch_skill.acquire.sources import classify_source, is_url_kind
 from watch_skill.errors import PerceptionError
 from watch_skill.perceive import PerceptionResult, perceive, probe
+from watch_skill.perceive.cues import discover_cues
 from watch_skill.perceive.types import VideoMetadata
 from watch_skill.transcribe import Transcript, get_transcript
 
@@ -126,6 +127,17 @@ def watch(
             width=None, height=None, fps=None, codec=None, has_audio=False,
         )
     _validate_window(start_seconds, end_seconds, metadata.duration_seconds)
+
+    # A recording made by `watch-skill capture --script` carries the moments
+    # its interactions happened at, and those are the frames it exists to
+    # show -- also the frames near-duplicate selection is likeliest to drop,
+    # a page where three numbers change hashing within the threshold of the
+    # page before it. Reading them here rather than in a surface is what gives
+    # every ingestion path the same behaviour: the CLI, MCP, REST, the job
+    # queue and the batch runner all arrive through this function. An explicit
+    # `cue_timestamps` is the caller naming the moments that matter, and wins.
+    if cue_timestamps is None and acq.video_path is not None:
+        cue_timestamps = discover_cues(acq.video_path, metadata.duration_seconds)
 
     progress("extracting frames (scenes, dedup, OCR)", 0.35)
     perception: PerceptionResult | None = None

--- a/tests/loop/test_capture_cues.py
+++ b/tests/loop/test_capture_cues.py
@@ -168,6 +168,27 @@ def test_the_cue_names_the_state_after_the_step_not_before_it(
 
 
 @pytest.mark.timeout(300)
+def test_a_wait_is_pinned_inside_the_wait_not_at_its_far_edge(
+    tmp_path: Path
+) -> None:
+    """The far edge of a wait is the instant the next step runs.
+
+    Measured: a cue stamped there caught a frame where the quantity box
+    already read the *next* value and the totals had not been recomputed --
+    a state that existed for about a tenth of a second and is the one frame
+    in that window nobody wants pinned.
+    """
+    script = [{"action": "wait", "seconds": 1.5}, *_SCRIPT]
+    result = capture(_page(tmp_path).resolve().as_uri(), tmp_path / "cap wait",
+                     script=script)
+    cues = read_sidecar(result.video_path) or []
+    assert len(cues) == 3
+    assert 0.4 < cues[0] < 1.4, (
+        f"the wait's cue is at {cues[0]:.2f}s, not inside the 1.5s wait")
+    assert cues[0] < cues[1], "the wait outlasted the interaction after it"
+
+
+@pytest.mark.timeout(300)
 def test_a_second_recording_into_the_same_place_leaves_no_stale_cues(
     tmp_path: Path
 ) -> None:

--- a/tests/loop/test_capture_cues.py
+++ b/tests/loop/test_capture_cues.py
@@ -57,8 +57,16 @@ _CHECKOUT = """<!doctype html>
 """
 
 #: Fill the quantity box twice. Two totals, both of which have to survive.
+#:
+#: The wait between them is about this test rather than about the product. Back
+#: to back, the first total is on screen only from its own repaint until the
+#: second edit's -- a window whose width is however long the harness took to
+#: notice the first one, which on a loaded runner is not the same number as it
+#: is here. The second edit is held off so the state has a life of its own, and
+#: a cue that lands anywhere sensible lands inside it.
 _SCRIPT = [
     {"action": "fill", "selector": "#qty", "value": "1"},
+    {"action": "wait", "seconds": 1},
     {"action": "fill", "selector": "#qty", "value": "4"},
 ]
 _FIRST_TOTAL = "22.00"
@@ -189,7 +197,7 @@ def test_a_wait_is_pinned_inside_the_wait_not_at_its_far_edge(
     result = capture(_page(tmp_path).resolve().as_uri(), tmp_path / "cap wait",
                      script=script)
     cues = read_sidecar(result.video_path) or []
-    assert len(cues) == 3
+    assert len(cues) == len(script)
     assert 0.4 < cues[0] < 1.4, (
         f"the wait's cue is at {cues[0]:.2f}s, not inside the 1.5s wait")
     assert cues[0] < cues[1], "the wait outlasted the interaction after it"
@@ -217,7 +225,7 @@ def test_an_explicit_timestamp_wins_over_a_recorded_one(tmp_path: Path) -> None:
     """`--timestamps` is the caller naming the moments that matter."""
     result = capture(_page(tmp_path).resolve().as_uri(), tmp_path / "cap explicit",
                      script=_SCRIPT)
-    assert len(read_sidecar(result.video_path) or []) == 2
+    assert len(read_sidecar(result.video_path) or []) == len(_SCRIPT)
 
     watched = watch(str(result.video_path), use_cache=False, run_ocr=False,
                     cue_timestamps=[0.2])

--- a/tests/loop/test_capture_cues.py
+++ b/tests/loop/test_capture_cues.py
@@ -12,6 +12,7 @@ returns, and a recording made twice into one directory overwrites the first.
 """
 from __future__ import annotations
 
+import json
 import re
 import threading
 from functools import partial
@@ -134,22 +135,28 @@ def test_both_numeric_states_survive_near_duplicate_selection(tmp_path: Path) ->
 def test_a_slow_first_navigation_does_not_move_every_later_moment(
     slow_site: str, tmp_path: Path
 ) -> None:
-    """The clock starts with the recording, not with the end of the navigation.
+    """Two seconds of this session are a browser waiting for a document.
 
-    Two seconds of this recording are the browser waiting for a document. A
-    clock started after `page.goto` returns calls the first interaction
-    "0.4 s", which in the recording is the blank page before the app rendered.
+    How much of that wait reaches the file is the browser's business -- it
+    emits screencast frames when it has something to emit -- so the two clocks
+    come out of it disagreeing by an amount nothing can predict. Asserting a
+    number here would be asserting how fast this machine is. What has to hold
+    is that the moments still land on the states they were recorded for.
     """
     result = capture(slow_site, tmp_path / "cap slow", script=_SCRIPT)
     cues = read_sidecar(result.video_path)
-    assert cues is not None
-    assert cues[0] > _SlowHandler.delay_seconds, (
-        f"the first interaction is recorded at {cues[0]:.2f}s, which is inside "
-        f"the {_SlowHandler.delay_seconds}s navigation that preceded it"
-    )
+    assert cues is not None and len(cues) == len(_SCRIPT)
+
+    sidecar = json.loads(
+        sidecar_path_for(result.video_path).read_text(encoding="utf-8"))
+    assert "offset" in sidecar["timeline"], (
+        "the recording was never aligned against the session clock")
+    assert all(0 <= cue <= sidecar["timeline"]["media_duration"] for cue in cues)
 
     watched = watch(str(result.video_path), use_cache=False, run_ocr=True)
     text = _ocr_text(watched)
+    assert "TOTAL" in text.upper(), (
+        f"the pinned frames are of the page before the app rendered: {text!r}")
     assert _SECOND_TOTAL in text, (
         f"the pinned frames are of the wrong moment: {text!r}")
 

--- a/tests/loop/test_capture_cues.py
+++ b/tests/loop/test_capture_cues.py
@@ -1,0 +1,233 @@
+"""What a scripted capture is for: the states it was recorded to show survive.
+
+The failure these exist for is measurable rather than theoretical. A checkout
+page where a quantity edit moves three numbers produces frames whose perceptual
+hashes are 4 apart, and the near-duplicate threshold is 6 -- so the frame that
+carries the change is dropped and a report is written from the page before it.
+
+Pinning the interaction fixes that only if the pin lands in the right place,
+which is what most of this file is about. Two clocks are involved and they do
+not share a length, a page does not finish reacting the instant a script step
+returns, and a recording made twice into one directory overwrites the first.
+"""
+from __future__ import annotations
+
+import re
+import threading
+from functools import partial
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("playwright", reason="loop extra not installed")
+
+from watch_skill.loop.capture import capture  # noqa: E402
+from watch_skill.perceive.cues import read_sidecar, sidecar_path_for  # noqa: E402
+from watch_skill.watch import watch  # noqa: E402
+
+#: A checkout whose total is recomputed a moment after the edit that causes it.
+#:
+#: The delay is the point. A cue taken the instant `page.fill` returns names a
+#: frame that still shows the old total, so a test against an instant-updating
+#: page would pass without the settle that makes the cue mean anything.
+_CHECKOUT = """<!doctype html>
+<html><head><meta charset="utf-8"><style>
+  body {{ font: 44px/1.5 "DejaVu Sans Mono", monospace; background: #fff;
+         color: #000; padding: 40px; }}
+  input {{ font: 44px "DejaVu Sans Mono", monospace; width: 3em; }}
+  .total {{ font-size: 64px; font-weight: bold; }}
+</style></head>
+<body>
+  <div>QTY <input id="qty" value="0"></div>
+  <div>SUBTOTAL <span id="subtotal">0.00</span></div>
+  <div class="total">TOTAL <span id="total">0.00</span></div>
+<script>
+  const PRICE = 22
+  const recompute = () => {{
+    const q = Number(document.getElementById('qty').value) || 0
+    document.getElementById('subtotal').textContent = (PRICE * q).toFixed(2)
+    document.getElementById('total').textContent = (PRICE * q).toFixed(2)
+  }}
+  document.getElementById('qty')
+    .addEventListener('input', () => setTimeout(recompute, {delay_ms}))
+</script>
+</body></html>
+"""
+
+#: Fill the quantity box twice. Two totals, both of which have to survive.
+_SCRIPT = [
+    {"action": "fill", "selector": "#qty", "value": "1"},
+    {"action": "fill", "selector": "#qty", "value": "4"},
+]
+_FIRST_TOTAL = "22.00"
+_SECOND_TOTAL = "88.00"
+
+
+def _page(tmp_path: Path, delay_ms: int = 350) -> Path:
+    page = tmp_path / "checkout dir" / "checkout.html"
+    page.parent.mkdir(parents=True, exist_ok=True)
+    page.write_text(_CHECKOUT.format(delay_ms=delay_ms), encoding="utf-8")
+    return page
+
+
+def _ocr_text(result) -> str:
+    """Everything OCR read, from the frames the cues pinned."""
+    frames = [f for f in result.perception.frames if f.reason == "cue"]
+    return " ".join(
+        block.text for frame in frames for block in (frame.ocr_blocks or [])
+    )
+
+
+def _cue_frames(result) -> list:
+    return [f for f in result.perception.frames if f.reason == "cue"]
+
+
+class _SlowHandler(SimpleHTTPRequestHandler):
+    """A server that takes its time over the document, and only the document."""
+
+    delay_seconds = 2.0
+
+    def do_GET(self) -> None:  # noqa: N802 — BaseHTTPRequestHandler's name
+        if self.path.endswith(".html") or self.path == "/":
+            threading.Event().wait(self.delay_seconds)
+        super().do_GET()
+
+    def log_message(self, *_args: object) -> None:
+        return
+
+
+@pytest.fixture()
+def slow_site(tmp_path: Path):
+    """The checkout, served by something that answers in its own time."""
+    root = _page(tmp_path).parent
+    handler = partial(_SlowHandler, directory=str(root))
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}/checkout.html"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+@pytest.mark.timeout(300)
+def test_both_numeric_states_survive_near_duplicate_selection(tmp_path: Path) -> None:
+    """The measured failure, end to end: two totals, both readable afterwards.
+
+    Without the cues these frames are 4 apart perceptually and the threshold
+    is 6, so the second one is dropped and the report describes the first.
+    """
+    result = capture(_page(tmp_path).resolve().as_uri(), tmp_path / "cap two states",
+                     script=_SCRIPT)
+    assert result.meta["cues"], "a scripted capture recorded no interactions"
+
+    watched = watch(str(result.video_path), use_cache=False, run_ocr=True)
+    text = _ocr_text(watched)
+    assert _FIRST_TOTAL in text, f"the first total was not kept: {text!r}"
+    assert _SECOND_TOTAL in text, f"the second total was not kept: {text!r}"
+
+
+@pytest.mark.timeout(300)
+def test_a_slow_first_navigation_does_not_move_every_later_moment(
+    slow_site: str, tmp_path: Path
+) -> None:
+    """The clock starts with the recording, not with the end of the navigation.
+
+    Two seconds of this recording are the browser waiting for a document. A
+    clock started after `page.goto` returns calls the first interaction
+    "0.4 s", which in the recording is the blank page before the app rendered.
+    """
+    result = capture(slow_site, tmp_path / "cap slow", script=_SCRIPT)
+    cues = read_sidecar(result.video_path)
+    assert cues is not None
+    assert cues[0] > _SlowHandler.delay_seconds, (
+        f"the first interaction is recorded at {cues[0]:.2f}s, which is inside "
+        f"the {_SlowHandler.delay_seconds}s navigation that preceded it"
+    )
+
+    watched = watch(str(result.video_path), use_cache=False, run_ocr=True)
+    text = _ocr_text(watched)
+    assert _SECOND_TOTAL in text, (
+        f"the pinned frames are of the wrong moment: {text!r}")
+
+
+@pytest.mark.timeout(300)
+def test_the_cue_names_the_state_after_the_step_not_before_it(
+    tmp_path: Path
+) -> None:
+    """A page that repaints late still gets pinned after it has repainted."""
+    result = capture(_page(tmp_path, delay_ms=700).resolve().as_uri(),
+                     tmp_path / "cap late", script=_SCRIPT[:1])
+    watched = watch(str(result.video_path), use_cache=False, run_ocr=True)
+    text = _ocr_text(watched)
+    assert _FIRST_TOTAL in text, (
+        f"pinned the frame before the page reacted to the edit: {text!r}")
+
+
+@pytest.mark.timeout(300)
+def test_a_second_recording_into_the_same_place_leaves_no_stale_cues(
+    tmp_path: Path
+) -> None:
+    """Capture writes a fixed name, so the second run replaces the first."""
+    out = tmp_path / "cap twice"
+    page = _page(tmp_path).resolve().as_uri()
+    first = capture(page, out, script=_SCRIPT)
+    assert sidecar_path_for(first.video_path).is_file()
+
+    second = capture(page, out, duration_seconds=2.0)  # unscripted
+    assert second.video_path == first.video_path
+    assert not sidecar_path_for(second.video_path).exists(), (
+        "the previous recording's interaction moments outlived it")
+    assert read_sidecar(second.video_path) is None
+
+
+@pytest.mark.timeout(300)
+def test_an_explicit_timestamp_wins_over_a_recorded_one(tmp_path: Path) -> None:
+    """`--timestamps` is the caller naming the moments that matter."""
+    result = capture(_page(tmp_path).resolve().as_uri(), tmp_path / "cap explicit",
+                     script=_SCRIPT)
+    assert len(read_sidecar(result.video_path) or []) == 2
+
+    watched = watch(str(result.video_path), use_cache=False, run_ocr=False,
+                    cue_timestamps=[0.2])
+    pinned = [round(f.timestamp_seconds, 3) for f in _cue_frames(watched)]
+    assert pinned == [0.2], f"the sidecar overrode the caller: {pinned}"
+
+
+@pytest.mark.timeout(300)
+def test_the_whole_path_finds_the_total_at_the_moment_it_appeared(
+    tmp_path: Path
+) -> None:
+    """Recording -> pinned frames -> OCR -> index -> retrieval, on real bytes.
+
+    The claim being checked is narrow and worth stating: a recording that
+    carries interaction cues keeps the states those interactions produced.
+    It says nothing about an arbitrary uploaded video, which carries none.
+    """
+    from watch_skill.index import ask_video, get_moment, index_watch_result
+
+    result = capture(_page(tmp_path).resolve().as_uri(), tmp_path / "cap indexed",
+                     script=_SCRIPT)
+    cues = read_sidecar(result.video_path) or []
+    watched = watch(str(result.video_path), use_cache=False, run_ocr=True)
+    video_id = index_watch_result(watched, describe_scenes=False)
+
+    answer = ask_video(video_id, f"what was the total {_SECOND_TOTAL}?")
+    carrying = [hit for hit in answer["hits"]
+                if _SECOND_TOTAL in hit["text"] and hit["timestamp"] is not None]
+    assert carrying, (
+        f"retrieval cannot find {_SECOND_TOTAL} in what it just indexed: "
+        f"{[h['text'] for h in answer['hits']]}")
+
+    at = carrying[0]["timestamp"]
+    assert any(abs(at - cue) < 1.0 for cue in cues), (
+        f"{_SECOND_TOTAL} was found at {at:.2f}s, which is not one of the "
+        f"moments the capture pinned: {cues}")
+    moment = get_moment(video_id, at, window=1.0)
+    read_there = " ".join(str(row.get("text", "")) for row in moment.ocr)
+    assert re.search(re.escape(_SECOND_TOTAL), read_there), (
+        f"the moment does not carry the reading it was retrieved for: "
+        f"{read_there!r}")

--- a/tests/perceive/test_cues.py
+++ b/tests/perceive/test_cues.py
@@ -22,6 +22,7 @@ from watch_skill.perceive.cues import (
     CueError,
     clear_sidecar,
     discover_cues,
+    measure_offset,
     read_sidecar,
     sidecar_path_for,
     to_media_timeline,
@@ -238,31 +239,93 @@ class TestDiscoveryDegradesLoudly:
 
 
 class TestTheMediaTimeline:
-    """The recording and the wall clock share an origin, not a length."""
+    """The two clocks run at the same rate and start at different moments."""
 
-    def test_a_recording_shorter_than_the_session_shifts_everything_earlier(
-        self,
-    ) -> None:
-        # 0.4 s of the session never made it into the file, and it is the 0.4 s
-        # at the front -- the screencast starts once the browser is ready to
-        # emit frames.
+    def test_a_measured_offset_moves_every_moment_by_the_same_amount(self) -> None:
+        # A screencast that started 0.28 s after the page did puts every later
+        # moment 0.28 s earlier in the file than the session clock says.
         assert to_media_timeline(
-            [1.0, 3.0, 5.0], wall_span=6.0, media_duration=5.6
-        ) == [0.6, 2.6, 4.6]
+            [1.0, 3.0, 5.0], offset=-0.28, media_duration=5.6
+        ) == [0.72, 2.72, 4.72]
 
     def test_a_moment_before_the_recording_starts_is_clamped_not_dropped(self) -> None:
-        assert to_media_timeline([0.1], wall_span=6.0, media_duration=5.0) == [0.0]
+        assert to_media_timeline([0.1], offset=-1.0, media_duration=5.0) == [0.0]
 
     def test_nothing_is_pushed_past_the_end(self) -> None:
-        assert to_media_timeline([6.0], wall_span=6.0, media_duration=5.0) == [5.0]
+        assert to_media_timeline([6.0], offset=0.5, media_duration=5.0) == [5.0]
 
     def test_an_unmeasurable_recording_leaves_the_moments_alone(self) -> None:
-        assert to_media_timeline([1.0, 2.0], wall_span=3.0, media_duration=0.0) == [
-            1.0, 2.0]
+        assert to_media_timeline(
+            [1.0, 2.0], offset=-0.5, media_duration=0.0) == [1.0, 2.0]
 
-    def test_the_offset_is_never_negative(self) -> None:
-        # A container that rounds its duration up must not push cues later.
-        assert to_media_timeline([1.0], wall_span=5.0, media_duration=5.2) == [1.0]
+    def test_no_measurement_means_no_correction(self) -> None:
+        # Nothing to align against is not a licence to invent an alignment.
+        assert to_media_timeline(
+            [1.0, 2.0], offset=0.0, media_duration=5.0) == [1.0, 2.0]
+
+
+class TestMeasuringTheOffset:
+    """The alignment is measured against the recording, never inferred."""
+
+    def _recording(self, tmp_path: Path, change_at: float, seconds: float) -> Path:
+        """A clip that is one colour and then abruptly another."""
+        import shutil
+        import subprocess
+
+        ffmpeg = shutil.which("ffmpeg")
+        if ffmpeg is None:
+            pytest.skip("ffmpeg not available")
+        out = tmp_path / "aligned" / "capture.mp4"
+        out.parent.mkdir(parents=True, exist_ok=True)
+        result = subprocess.run([
+            ffmpeg, "-hide_banner", "-loglevel", "error", "-y",
+            "-f", "lavfi", "-i", f"color=c=black:s=320x240:r=25:d={change_at}",
+            "-f", "lavfi", "-i",
+            f"color=c=white:s=320x240:r=25:d={seconds - change_at}",
+            "-filter_complex", "[0:v][1:v]concat=n=2:v=1[v]", "-map", "[v]",
+            "-c:v", "libx264", "-pix_fmt", "yuv420p", str(out),
+        ], capture_output=True, text=True)
+        if result.returncode != 0:
+            pytest.skip(f"ffmpeg could not build the fixture: {result.stderr[-200:]}")
+        return out
+
+    def test_it_finds_how_far_the_recording_lags_the_session_clock(
+        self, tmp_path: Path
+    ) -> None:
+        # The change is at 1.0 s in the file. A session that saw it at 1.30 s
+        # was running 0.30 s ahead of the recording.
+        video = self._recording(tmp_path, change_at=1.0, seconds=3.0)
+        offset = measure_offset(video, changed_at=1.30, media_duration=3.0)
+        assert offset is not None
+        assert offset == pytest.approx(-0.30, abs=0.12)
+
+    def test_it_finds_a_session_clock_that_lags_the_recording(
+        self, tmp_path: Path
+    ) -> None:
+        video = self._recording(tmp_path, change_at=1.5, seconds=3.0)
+        offset = measure_offset(video, changed_at=1.2, media_duration=3.0)
+        assert offset is not None
+        assert offset == pytest.approx(0.30, abs=0.12)
+
+    def test_a_recording_that_never_changes_aligns_to_nothing(
+        self, tmp_path: Path
+    ) -> None:
+        video = self._recording(tmp_path, change_at=3.0, seconds=3.0)
+        assert measure_offset(video, changed_at=1.0, media_duration=3.0) is None
+
+    def test_an_absurd_result_is_refused_rather_than_applied(
+        self, tmp_path: Path
+    ) -> None:
+        # Half a minute apart is not a measurement of the same event.
+        video = self._recording(tmp_path, change_at=1.0, seconds=3.0)
+        assert measure_offset(video, changed_at=30.0, media_duration=3.0) is None
+
+    def test_the_search_gives_up_rather_than_reading_a_whole_film(
+        self, tmp_path: Path
+    ) -> None:
+        video = self._recording(tmp_path, change_at=1.0, seconds=3.0)
+        assert measure_offset(
+            video, changed_at=1.0, media_duration=3.0, search_seconds=0.3) is None
 
 
 class TestRoundTripping:
@@ -286,7 +349,7 @@ class TestRoundTripping:
         # something strange and a file the reader then has to refuse. It is
         # also length-preserving, because the caller pairs it with labels.
         mapped = to_media_timeline(
-            [math.inf, math.nan, -5.0, 2.0], wall_span=6.0, media_duration=5.0)
+            [math.inf, math.nan, -5.0, 2.0], offset=-0.3, media_duration=5.0)
         assert len(mapped) == 4
         assert all(math.isfinite(value) and value >= 0 for value in mapped)
         write_sidecar(recording, [Cue(value) for value in mapped])

--- a/tests/perceive/test_cues.py
+++ b/tests/perceive/test_cues.py
@@ -1,0 +1,293 @@
+"""The cue sidecar, held to being worth acting on without being read first.
+
+A sidecar is discovered, not requested: the pipeline finds it beside a
+recording and pins frames from it. That makes every one of these a real
+scenario rather than a hypothetical -- the file sits in a directory a user can
+write to, an earlier capture can have left one behind, and half-written JSON
+is a shape `[]` and `null` actually take.
+"""
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+
+import pytest
+
+from watch_skill.identity import digest_file
+from watch_skill.perceive.cues import (
+    MAX_CUES,
+    MAX_SIDECAR_BYTES,
+    Cue,
+    CueError,
+    clear_sidecar,
+    discover_cues,
+    read_sidecar,
+    sidecar_path_for,
+    to_media_timeline,
+    write_sidecar,
+)
+
+
+@pytest.fixture()
+def recording(tmp_path: Path) -> Path:
+    """A stand-in for a capture: the loader reads bytes, never pixels."""
+    video = tmp_path / "recording dir" / "capture.webm"
+    video.parent.mkdir(parents=True)
+    video.write_bytes(b"not really a video, but it has a size and a digest")
+    return video
+
+
+def _sidecar(video: Path, payload: object) -> Path:
+    path = sidecar_path_for(video)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _bound(video: Path, cues: list[object], **extra: object) -> dict[str, object]:
+    return {
+        "version": 1,
+        "recording": {
+            "name": video.name,
+            "bytes": video.stat().st_size,
+            "sha256": digest_file(video),
+        },
+        "cues": cues,
+        **extra,
+    }
+
+
+class TestTheHappyPath:
+    def test_a_written_sidecar_reads_back(self, recording: Path) -> None:
+        write_sidecar(recording, [Cue(1.5, "fill #qty"), Cue(3.25, "click #apply")])
+        assert read_sidecar(recording) == [1.5, 3.25]
+
+    def test_the_sidecar_sits_beside_the_recording(self, recording: Path) -> None:
+        written = write_sidecar(recording, [Cue(1.0)])
+        assert written == recording.parent / "capture.cues.json"
+
+    def test_no_sidecar_is_not_an_error(self, recording: Path) -> None:
+        assert read_sidecar(recording) is None
+
+    def test_an_empty_list_pins_nothing(self, recording: Path) -> None:
+        _sidecar(recording, _bound(recording, []))
+        assert read_sidecar(recording) is None
+
+    def test_a_label_is_carried_and_the_seconds_still_read(self, recording: Path) -> None:
+        _sidecar(recording, _bound(recording, [{"seconds": 2.0, "label": "fill #qty"}]))
+        assert read_sidecar(recording) == [2.0]
+
+    def test_a_hand_written_override_needs_no_binding(self, recording: Path) -> None:
+        # Nothing claims this came from a capture, so there is no earlier
+        # recording it could be describing instead.
+        _sidecar(recording, {"cues": [1.0, 2.0]})
+        assert read_sidecar(recording) == [1.0, 2.0]
+
+
+class TestAStaleSidecarIsNeverApplied:
+    """The scenario: capture twice into one directory, unscripted the second time.
+
+    The video is overwritten because capture writes a fixed name. A sidecar
+    that survived that would pin real moments from the wrong session, and
+    nothing downstream could tell -- the times are in range and the frames
+    come out fine, they are simply of something else.
+    """
+
+    def test_a_digest_that_does_not_match_is_refused(self, recording: Path) -> None:
+        _sidecar(recording, _bound(recording, [1.0]))
+        recording.write_bytes(b"a different recording, written over the first one")
+        with pytest.raises(CueError) as caught:
+            read_sidecar(recording)
+        assert caught.value.code == "cues.stale"
+        assert "delete" in (caught.value.fix or "")
+
+    def test_a_size_that_does_not_match_is_refused(self, recording: Path) -> None:
+        payload = _bound(recording, [1.0])
+        payload["recording"]["bytes"] = 999_999  # type: ignore[index]
+        _sidecar(recording, payload)
+        with pytest.raises(CueError) as caught:
+            read_sidecar(recording)
+        assert caught.value.code == "cues.stale"
+
+    def test_a_capture_sidecar_that_names_no_recording_is_refused(
+        self, recording: Path
+    ) -> None:
+        _sidecar(recording, {"version": 1, "cues": [1.0]})
+        with pytest.raises(CueError) as caught:
+            read_sidecar(recording)
+        assert caught.value.code == "cues.unbound"
+
+    def test_clearing_removes_it_and_tolerates_absence(self, recording: Path) -> None:
+        write_sidecar(recording, [Cue(1.0)])
+        clear_sidecar(recording)
+        assert not sidecar_path_for(recording).exists()
+        clear_sidecar(recording)  # a second call is not an error
+
+
+class TestNothingInTheFileIsTakenOnTrust:
+    @pytest.mark.parametrize("payload", [[], None, 3, "cues", True])
+    def test_a_root_that_is_not_an_object_is_refused(
+        self, recording: Path, payload: object
+    ) -> None:
+        # `[]` and `null` are what a half-written file looks like, and `.get`
+        # on either is an AttributeError nobody upstream is catching.
+        _sidecar(recording, payload)
+        with pytest.raises(CueError) as caught:
+            read_sidecar(recording)
+        assert caught.value.code == "cues.bad_schema"
+
+    def test_cues_that_are_not_a_list_are_refused(self, recording: Path) -> None:
+        _sidecar(recording, _bound(recording, {"first": 1.0}))  # type: ignore[arg-type]
+        with pytest.raises(CueError) as caught:
+            read_sidecar(recording)
+        assert caught.value.code == "cues.bad_schema"
+
+    def test_unparseable_json_is_refused(self, recording: Path) -> None:
+        sidecar_path_for(recording).write_text("{not json", encoding="utf-8")
+        with pytest.raises(CueError) as caught:
+            read_sidecar(recording)
+        assert caught.value.code == "cues.unreadable"
+
+    @pytest.mark.parametrize(
+        ("value", "why"),
+        [
+            (True, "a bool is an int, and True would pin a frame at one second"),
+            (False, "the same, at zero"),
+            (-1.0, "before the recording starts"),
+            ("2.0", "a string is not a number"),
+            (None, "a hole where a number should be"),
+            ({"label": "fill"}, "an object with no seconds"),
+        ],
+    )
+    def test_a_value_that_is_not_a_moment_is_refused(
+        self, recording: Path, value: object, why: str
+    ) -> None:
+        _sidecar(recording, _bound(recording, [1.0, value]))
+        with pytest.raises(CueError) as caught:
+            read_sidecar(recording)
+        assert caught.value.code == "cues.bad_timestamp", why
+
+    @pytest.mark.parametrize("literal", ["NaN", "Infinity", "-Infinity"])
+    def test_non_finite_numbers_are_refused(self, recording: Path, literal: str) -> None:
+        # `json.loads` accepts these by default, so they reach the filter as
+        # floats and `isinstance(x, float)` says yes to all three.
+        raw = json.dumps(_bound(recording, [1.0])).replace("[1.0]", f"[{literal}]")
+        sidecar_path_for(recording).write_text(raw, encoding="utf-8")
+        with pytest.raises(CueError) as caught:
+            read_sidecar(recording)
+        assert caught.value.code == "cues.bad_timestamp"
+
+    def test_more_cues_than_there_is_budget_for_are_refused(
+        self, recording: Path
+    ) -> None:
+        _sidecar(recording, _bound(recording, [float(i) for i in range(MAX_CUES + 1)]))
+        with pytest.raises(CueError) as caught:
+            read_sidecar(recording)
+        assert caught.value.code == "cues.too_many"
+
+    def test_a_file_too_large_to_be_a_cue_list_is_not_read(
+        self, recording: Path
+    ) -> None:
+        sidecar_path_for(recording).write_text(
+            " " * (MAX_SIDECAR_BYTES + 1), encoding="utf-8")
+        with pytest.raises(CueError) as caught:
+            read_sidecar(recording)
+        assert caught.value.code == "cues.too_large"
+
+    def test_every_refusal_says_what_to_do_about_it(self, recording: Path) -> None:
+        _sidecar(recording, [])
+        with pytest.raises(CueError) as caught:
+            read_sidecar(recording)
+        assert caught.value.fix, "a diagnostic with no action is not actionable"
+        assert str(caught.value).startswith(f"[{caught.value.code}]")
+
+
+class TestBoundsAgainstTheRecording:
+    def test_a_cue_past_the_end_is_refused(self, recording: Path) -> None:
+        _sidecar(recording, _bound(recording, [1.0, 40.0]))
+        with pytest.raises(CueError) as caught:
+            read_sidecar(recording, duration_seconds=10.0)
+        assert caught.value.code == "cues.out_of_bounds"
+
+    def test_the_last_moment_of_a_session_is_trimmed_not_refused(
+        self, recording: Path
+    ) -> None:
+        # A duration read from a container and a moment read from a clock do
+        # not agree to the millisecond, and the last cue lands at the end.
+        _sidecar(recording, _bound(recording, [9.98, 10.2]))
+        assert read_sidecar(recording, duration_seconds=10.0) == [9.98, 10.0]
+
+    def test_without_a_duration_nothing_is_bounded(self, recording: Path) -> None:
+        _sidecar(recording, _bound(recording, [40.0]))
+        assert read_sidecar(recording) == [40.0]
+
+
+class TestDiscoveryDegradesLoudly:
+    def test_a_broken_sidecar_does_not_fail_the_watch(
+        self, recording: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _sidecar(recording, {"version": 1, "cues": [1.0]})  # unbound
+        assert discover_cues(recording) is None
+        said = capsys.readouterr().err
+        assert "cues.unbound" in said
+        assert "ignoring interaction cues" in said
+
+    def test_a_good_sidecar_is_returned(self, recording: Path) -> None:
+        write_sidecar(recording, [Cue(2.0)])
+        assert discover_cues(recording) == [2.0]
+
+
+class TestTheMediaTimeline:
+    """The recording and the wall clock share an origin, not a length."""
+
+    def test_a_recording_shorter_than_the_session_shifts_everything_earlier(
+        self,
+    ) -> None:
+        # 0.4 s of the session never made it into the file, and it is the 0.4 s
+        # at the front -- the screencast starts once the browser is ready to
+        # emit frames.
+        assert to_media_timeline(
+            [1.0, 3.0, 5.0], wall_span=6.0, media_duration=5.6
+        ) == [0.6, 2.6, 4.6]
+
+    def test_a_moment_before_the_recording_starts_is_clamped_not_dropped(self) -> None:
+        assert to_media_timeline([0.1], wall_span=6.0, media_duration=5.0) == [0.0]
+
+    def test_nothing_is_pushed_past_the_end(self) -> None:
+        assert to_media_timeline([6.0], wall_span=6.0, media_duration=5.0) == [5.0]
+
+    def test_an_unmeasurable_recording_leaves_the_moments_alone(self) -> None:
+        assert to_media_timeline([1.0, 2.0], wall_span=3.0, media_duration=0.0) == [
+            1.0, 2.0]
+
+    def test_the_offset_is_never_negative(self) -> None:
+        # A container that rounds its duration up must not push cues later.
+        assert to_media_timeline([1.0], wall_span=5.0, media_duration=5.2) == [1.0]
+
+
+class TestRoundTripping:
+    def test_a_written_sidecar_survives_its_own_validator(
+        self, recording: Path
+    ) -> None:
+        write_sidecar(
+            recording,
+            [Cue(0.5, "fill #qty"), Cue(2.25, "click #apply")],
+            timeline={"wall_span": 4.0, "media_duration": 3.6},
+        )
+        payload = json.loads(sidecar_path_for(recording).read_text(encoding="utf-8"))
+        assert payload["timeline"] == {"wall_span": 4.0, "media_duration": 3.6}
+        assert payload["recording"]["sha256"] == digest_file(recording)
+        assert read_sidecar(recording, duration_seconds=3.6) == [0.5, 2.25]
+
+    def test_the_writer_never_emits_a_value_the_reader_would_refuse(
+        self, recording: Path
+    ) -> None:
+        # The mapping is the last thing between a clock that produced
+        # something strange and a file the reader then has to refuse. It is
+        # also length-preserving, because the caller pairs it with labels.
+        mapped = to_media_timeline(
+            [math.inf, math.nan, -5.0, 2.0], wall_span=6.0, media_duration=5.0)
+        assert len(mapped) == 4
+        assert all(math.isfinite(value) and value >= 0 for value in mapped)
+        write_sidecar(recording, [Cue(value) for value in mapped])
+        assert read_sidecar(recording, duration_seconds=5.0) == mapped

--- a/tests/surfaces/test_cue_ingestion.py
+++ b/tests/surfaces/test_cue_ingestion.py
@@ -1,0 +1,169 @@
+"""Every supported way in reads a recording's own interaction moments.
+
+The first version of this behaviour lived in the CLI's `watch` command, which
+meant `watch-skill watch` pinned the interactions and nothing else did: not the
+MCP tool an agent calls, not the REST route the workspace calls, not the job
+queue, not `batch`. DeepWatch ingests through `watch-skill watch --index`, so
+the one path that worked was also the only one anybody had looked at.
+
+It lives in the engine now. These tests are about the seam rather than the
+behaviour -- that each route arrives at the same function, and that no surface
+has grown a second copy of it.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("scenedetect", reason="perceive extra not installed")
+
+from watch_skill.identity import digest_file  # noqa: E402
+from watch_skill.perceive.cues import Cue, read_sidecar, write_sidecar  # noqa: E402
+
+SURFACES = Path(__file__).resolve().parents[2] / "src" / "watch_skill" / "surfaces"
+
+
+@pytest.fixture()
+def recording_with_cues(sample_video: Path, tmp_path: Path) -> Path:
+    """A copy of the sample clip with a cue in the middle of it."""
+    import shutil
+
+    video = tmp_path / "ingest dir" / "capture.mp4"
+    video.parent.mkdir(parents=True)
+    shutil.copy2(sample_video, video)
+    write_sidecar(video, [Cue(6.0, "fill #qty")])
+    assert read_sidecar(video) == [6.0]
+    return video
+
+
+@pytest.fixture()
+def spy(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, float | None]]:
+    """Record every call the engine makes to the shared loader."""
+    calls: list[tuple[str, float | None]] = []
+    import watch_skill.watch as engine
+
+    real = engine.discover_cues
+
+    def recorded(video_path, duration_seconds=None):  # noqa: ANN001, ANN202
+        calls.append((Path(video_path).name, duration_seconds))
+        return real(video_path, duration_seconds)
+
+    monkeypatch.setattr(engine, "discover_cues", recorded)
+    return calls
+
+
+def _quiet(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No whisper download and no OCR pass; this is about the seam."""
+    from watch_skill.config import reset_settings
+
+    monkeypatch.setenv("WATCHSKILL_LOCAL_WHISPER_ENABLED", "false")
+    monkeypatch.setenv("WATCHSKILL_OCR_ENABLED", "false")
+    reset_settings()
+
+
+class TestEveryRouteReachesTheLoader:
+    def test_the_engine_itself(
+        self, recording_with_cues: Path, spy: list, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _quiet(monkeypatch)
+        from watch_skill.watch import watch
+
+        result = watch(str(recording_with_cues), use_cache=False, max_frames=6)
+        assert spy == [("capture.mp4", pytest.approx(12.0, abs=1.0))]
+        pinned = [f.timestamp_seconds for f in result.perception.frames
+                  if f.reason == "cue"]
+        assert pinned == [6.0], f"the cue did not pin a frame: {pinned}"
+
+    def test_the_cli(
+        self, recording_with_cues: Path, spy: list, monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        # The route DeepWatch ingests through: `watch-skill watch <file> --index`.
+        _quiet(monkeypatch)
+        from typer.testing import CliRunner
+
+        from watch_skill.surfaces.cli.main import app
+
+        result = CliRunner().invoke(app, [
+            "watch", str(recording_with_cues), "--no-whisper", "--no-ocr",
+            "--out-dir", str(tmp_path / "cli out"), "--max-frames", "6",
+        ])
+        assert result.exit_code == 0, result.output
+        assert [name for name, _ in spy] == ["capture.mp4"]
+
+    def test_the_rest_route(
+        self, recording_with_cues: Path, spy: list, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pytest.importorskip("fastapi", reason="api extra not installed")
+        from fastapi.testclient import TestClient
+
+        from watch_skill.surfaces.api import create_app
+
+        _quiet(monkeypatch)
+        client = TestClient(create_app())
+        response = client.post("/v1/watch", json={
+            "source": str(recording_with_cues), "budget": 6})
+        assert response.status_code == 200, response.text
+        assert [name for name, _ in spy] == ["capture.mp4"]
+
+    def test_the_mcp_tool(
+        self, recording_with_cues: Path, spy: list, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _quiet(monkeypatch)
+        from watch_skill.surfaces.mcp.server import _run_watch
+
+        _run_watch(str(recording_with_cues), None, None, 6, lambda *_a: None)
+        assert [name for name, _ in spy] == ["capture.mp4"]
+
+    def test_the_job_queue(
+        self, recording_with_cues: Path, spy: list, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _quiet(monkeypatch)
+        from watch_skill.jobs.handlers import _watch_job
+
+        class _Context:
+            payload = {"source": str(recording_with_cues), "budget": 6}
+
+            def checkpoint(self, *_args: object, **_kwargs: object) -> None:
+                return
+
+        _watch_job(_Context())
+        assert [name for name, _ in spy] == ["capture.mp4"]
+
+
+class TestNoSurfaceKeepsItsOwnCopy:
+    def test_nothing_under_surfaces_reads_a_sidecar_itself(self) -> None:
+        """A second reader is a second set of validation rules to forget.
+
+        The CLI's copy accepted booleans, negatives, NaN and a timestamp past
+        the end of the recording, and raised an uncaught AttributeError on the
+        two shapes a half-written file actually takes.
+        """
+        offenders = [
+            path.relative_to(SURFACES).as_posix()
+            for path in SURFACES.rglob("*.py")
+            if "cues.json" in path.read_text(encoding="utf-8")
+        ]
+        assert offenders == [], (
+            "these surfaces read the cue sidecar directly instead of leaving "
+            f"it to the engine: {offenders}")
+
+
+class TestTheBindingIsCheckedOnTheWayIn:
+    def test_a_sidecar_from_another_recording_is_not_applied(
+        self, recording_with_cues: Path, monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _quiet(monkeypatch)
+        from watch_skill.watch import watch
+
+        # The scenario: capture twice into one directory. The video is
+        # replaced and the cues are not.
+        recording_with_cues.write_bytes(
+            (recording_with_cues.parent / "capture.mp4").read_bytes() + b"\0")
+        assert digest_file(recording_with_cues)
+
+        result = watch(str(recording_with_cues), use_cache=False, max_frames=6)
+        assert [f for f in result.perception.frames if f.reason == "cue"] == []
+        assert "cues.stale" in capsys.readouterr().err

--- a/tests/test_release_surface.py
+++ b/tests/test_release_surface.py
@@ -133,14 +133,17 @@ class TestTheExemptionIsScopedToOneOccurrence:
     @staticmethod
     def _findings_for(line: str) -> list[str]:
         cases = TestTheExemptionIsScopedToOneOccurrence
-        original = cases.EXEMPTED.read_text(encoding="utf-8")
+        # Bytes, not text: `write_text` emits os.linesep, which would rewrite
+        # this tracked file's endings on Windows.
+        original = cases.EXEMPTED.read_bytes()
         try:
             cases.EXEMPTED.write_text(f"{original}\n{line}\n", encoding="utf-8")
             relative = str(cases.EXEMPTED.relative_to(REPO)).replace("\\", "/")
-            found = findings_in(relative, cases.EXEMPTED.read_text(encoding="utf-8"))
+            found = findings_in(
+                relative, cases.EXEMPTED.read_bytes().decode("utf-8"))
             return [f for f in found if "[phantom-repository]" in f]
         finally:
-            cases.EXEMPTED.write_text(original, encoding="utf-8")
+            cases.EXEMPTED.write_bytes(original)
 
     def test_the_allowed_row_is_not_reported_however_it_is_spaced(self) -> None:
         cases = json.loads(

--- a/tests/test_release_surface.py
+++ b/tests/test_release_surface.py
@@ -33,16 +33,18 @@ RULES = [
 ]
 #: Exemptions, keyed by (file, rule).
 #:
-#: ``None`` excuses the whole file. A tuple of strings excuses only the lines
-#: containing one of them, so a file may hold one legitimate phrase a rule
-#: would otherwise flag without going blind to every other occurrence.
-EXEMPT: dict[tuple[str, str], tuple[str, ...] | None] = {}
+#: ``None`` excuses the whole file. A tuple of compiled patterns excuses only
+#: the occurrences whose preceding text matches — one match at a time, never a
+#: whole line, so a legitimate identifier and a stale reference can share a line
+#: and only the first is excused.
+EXEMPT: dict[tuple[str, str], tuple[re.Pattern[str], ...] | None] = {}
 for _entry in CONFIG["exemptions"]:
     _key = (_entry["file"], _entry["rule"])
-    if "contains" not in _entry:
+    if "precededBy" not in _entry:
         EXEMPT[_key] = None
     elif EXEMPT.get(_key, ()) is not None:
-        EXEMPT[_key] = tuple(EXEMPT.get(_key) or ()) + (_entry["contains"],)
+        EXEMPT[_key] = tuple(EXEMPT.get(_key) or ()) + (re.compile(_entry["precededBy"]),)
+
 
 #: Text that is fine in source and not fine in something a user is handed.
 #:
@@ -60,9 +62,13 @@ def findings_in(label: str, text: str, key: str | None = None) -> list[str]:
         if exempt_key in EXEMPT and allowed is None:
             continue
         for number, line in enumerate(text.splitlines(), start=1):
-            match = pattern.search(line)
-            if match and any(a in line for a in (allowed or ())):
-                continue
+            match = None
+            for candidate in pattern.finditer(line):
+                prefix = line[: candidate.start()]
+                if any(a.search(prefix) for a in (allowed or ())):
+                    continue
+                match = candidate
+                break
             if match:
                 found.append(f"{label}:{number} [{rule_id}] {why} -- {line.strip()[:110]}")
                 break
@@ -111,6 +117,44 @@ class TestTheRuleTableIsShared:
                 f"{rule_id} uses a lookbehind; keep the table to syntax both "
                 "engines read the same way"
             )
+
+
+class TestTheExemptionIsScopedToOneOccurrence:
+    """`watch-workspace` is a profile row id and a repository that does not exist.
+
+    The exemption must excuse the row and nothing else: not the whole file,
+    which would blind the rule where the confusing name lives, and not the
+    whole line, which would hide a stale reference sitting beside the row.
+    These cases are shared with workspace/tests/release-surface.test.mjs.
+    """
+
+    EXEMPTED = REPO / "workspace" / "packages" / "watch" / "workspace" / "README.md"
+
+    @staticmethod
+    def _findings_for(line: str) -> list[str]:
+        cases = TestTheExemptionIsScopedToOneOccurrence
+        original = cases.EXEMPTED.read_text(encoding="utf-8")
+        try:
+            cases.EXEMPTED.write_text(f"{original}\n{line}\n", encoding="utf-8")
+            relative = str(cases.EXEMPTED.relative_to(REPO)).replace("\\", "/")
+            found = findings_in(relative, cases.EXEMPTED.read_text(encoding="utf-8"))
+            return [f for f in found if "[phantom-repository]" in f]
+        finally:
+            cases.EXEMPTED.write_text(original, encoding="utf-8")
+
+    def test_the_allowed_row_is_not_reported_however_it_is_spaced(self) -> None:
+        cases = json.loads(
+            (REPO / "release-surface-fixtures.json").read_text(encoding="utf-8"))
+        for line in cases["$exemptions"]["phantom-repository"]["clean"]:
+            assert self._findings_for(line) == [], (
+                f"reported a legitimate profile row: {line!r}")
+
+    def test_a_genuine_stale_reference_is_reported_including_beside_the_row(self) -> None:
+        cases = json.loads(
+            (REPO / "release-surface-fixtures.json").read_text(encoding="utf-8"))
+        for line in cases["$exemptions"]["phantom-repository"]["reported"]:
+            assert len(self._findings_for(line)) == 1, (
+                f"missed a stale repository reference: {line!r}")
 
 
 class TestTheCliHelpIsCleanText:

--- a/tests/test_release_surface.py
+++ b/tests/test_release_surface.py
@@ -67,6 +67,28 @@ class TestTheRuleTableIsShared:
             assert pattern.pattern, f"{rule_id} has no pattern"
             assert len(why) > 15, f"{rule_id} does not say why it matters"
 
+    def test_the_shared_fixtures_hold_in_this_engine_too(self) -> None:
+        """One fixture file, read by this suite and by the Node one.
+
+        `phantom-repository` shipped broken twice because each engine kept its
+        own cases: once with a literal backspace that matched nothing here, and
+        once with a lookbehind that missed Markdown and ``repository:`` forms.
+        A shared file is what stops a rule being green in one engine and blind
+        in the other.
+        """
+        fixtures = json.loads(
+            (REPO / "release-surface-fixtures.json").read_text(encoding="utf-8"))
+        by_id = {rule_id: pattern for rule_id, pattern, _why in RULES}
+        for rule_id, cases in fixtures.items():
+            if rule_id.startswith("$"):
+                continue
+            assert rule_id in by_id, f"{rule_id} has fixtures but is not a rule"
+            pattern = by_id[rule_id]
+            for text in cases["catches"]:
+                assert pattern.search(text), f"{rule_id} must catch: {text}"
+            for text in cases["allows"]:
+                assert not pattern.search(text), f"{rule_id} must not fire on: {text}"
+
     def test_the_patterns_compile_the_same_way_in_both_engines(self) -> None:
         """A JS-only construct in the table would silently never match here."""
         for rule_id, pattern, _why in RULES:

--- a/tests/test_release_surface.py
+++ b/tests/test_release_surface.py
@@ -31,7 +31,18 @@ CONFIG = json.loads((REPO / "release-surface-rules.json").read_text(encoding="ut
 RULES = [
     (rule["id"], re.compile(rule["pattern"]), rule["why"]) for rule in CONFIG["rules"]
 ]
-EXEMPT = {(entry["file"], entry["rule"]) for entry in CONFIG["exemptions"]}
+#: Exemptions, keyed by (file, rule).
+#:
+#: ``None`` excuses the whole file. A tuple of strings excuses only the lines
+#: containing one of them, so a file may hold one legitimate phrase a rule
+#: would otherwise flag without going blind to every other occurrence.
+EXEMPT: dict[tuple[str, str], tuple[str, ...] | None] = {}
+for _entry in CONFIG["exemptions"]:
+    _key = (_entry["file"], _entry["rule"])
+    if "contains" not in _entry:
+        EXEMPT[_key] = None
+    elif EXEMPT.get(_key, ()) is not None:
+        EXEMPT[_key] = tuple(EXEMPT.get(_key) or ()) + (_entry["contains"],)
 
 #: Text that is fine in source and not fine in something a user is handed.
 #:
@@ -44,10 +55,14 @@ DETECTOR_FILES = {"scripts/secret_scan.py", "scripts/validate_agent_docs.py"}
 def findings_in(label: str, text: str, key: str | None = None) -> list[str]:
     found = []
     for rule_id, pattern, why in RULES:
-        if ((key or label), rule_id) in EXEMPT:
+        exempt_key = ((key or label), rule_id)
+        allowed = EXEMPT.get(exempt_key, ())
+        if exempt_key in EXEMPT and allowed is None:
             continue
         for number, line in enumerate(text.splitlines(), start=1):
             match = pattern.search(line)
+            if match and any(a in line for a in (allowed or ())):
+                continue
             if match:
                 found.append(f"{label}:{number} [{rule_id}] {why} -- {line.strip()[:110]}")
                 break

--- a/tests/test_release_surface.py
+++ b/tests/test_release_surface.py
@@ -131,33 +131,74 @@ class TestTheExemptionIsScopedToOneOccurrence:
     EXEMPTED = REPO / "workspace" / "packages" / "watch" / "workspace" / "README.md"
 
     @staticmethod
-    def _findings_for(line: str) -> list[str]:
+    def _appended(line: str) -> tuple[list[str], bytes]:
+        """Scan the real file with ``line`` appended; return findings and bytes.
+
+        Bytes throughout, for two separate reasons. `write_text` emits
+        `os.linesep`, which would rewrite this tracked file's endings on
+        Windows — and interpolating the bytes that were read into an f-string
+        writes their *repr*: ``b'# @deepwatch...\\n\\n- id: ...'``, one long
+        line of escapes where the file used to be. Scanning that is not
+        scanning this file. The exempted row stops being at the start of a
+        line, every other line stops existing, and what the rule then reports
+        is a fact about a string the test invented.
+        """
         cases = TestTheExemptionIsScopedToOneOccurrence
-        # Bytes, not text: `write_text` emits os.linesep, which would rewrite
-        # this tracked file's endings on Windows.
         original = cases.EXEMPTED.read_bytes()
         try:
-            cases.EXEMPTED.write_text(f"{original}\n{line}\n", encoding="utf-8")
+            cases.EXEMPTED.write_bytes(original + f"\n{line}\n".encode())
+            written = cases.EXEMPTED.read_bytes()
             relative = str(cases.EXEMPTED.relative_to(REPO)).replace("\\", "/")
-            found = findings_in(
-                relative, cases.EXEMPTED.read_bytes().decode("utf-8"))
-            return [f for f in found if "[phantom-repository]" in f]
+            found = findings_in(relative, written.decode("utf-8"))
+            return [f for f in found if "[phantom-repository]" in f], written
         finally:
             cases.EXEMPTED.write_bytes(original)
 
+    @classmethod
+    def _findings_for(cls, line: str) -> list[str]:
+        return cls._appended(line)[0]
+
+    @staticmethod
+    def _cases() -> dict[str, list[str]]:
+        return json.loads(
+            (REPO / "release-surface-fixtures.json").read_text(encoding="utf-8")
+        )["$exemptions"]["phantom-repository"]
+
+    def test_the_scanned_fixture_is_the_real_file_plus_the_line(self) -> None:
+        # If the fixture is not the file it claims to be, every assertion
+        # below is about something else.
+        original = self.EXEMPTED.read_bytes()
+        line = self._cases()["clean"][0]
+        _found, written = self._appended(line)
+        assert written.startswith(original), "rewritten rather than appended to"
+        assert written.endswith(f"\n{line}\n".encode())
+        assert b"\\n" not in written, "the bytes were interpolated, not appended"
+        assert written.decode("utf-8").splitlines()[-1] == line
+
+    def test_the_original_bytes_come_back_exactly(self) -> None:
+        original = self.EXEMPTED.read_bytes()
+        self._findings_for("Clone watch-workspace and run pnpm install.")
+        assert self.EXEMPTED.read_bytes() == original, (
+            "a tracked file did not survive the scan byte for byte")
+
     def test_the_allowed_row_is_not_reported_however_it_is_spaced(self) -> None:
-        cases = json.loads(
-            (REPO / "release-surface-fixtures.json").read_text(encoding="utf-8"))
-        for line in cases["$exemptions"]["phantom-repository"]["clean"]:
+        for line in self._cases()["clean"]:
             assert self._findings_for(line) == [], (
                 f"reported a legitimate profile row: {line!r}")
 
     def test_a_genuine_stale_reference_is_reported_including_beside_the_row(self) -> None:
-        cases = json.loads(
-            (REPO / "release-surface-fixtures.json").read_text(encoding="utf-8"))
-        for line in cases["$exemptions"]["phantom-repository"]["reported"]:
-            assert len(self._findings_for(line)) == 1, (
+        own_lines = len(self.EXEMPTED.read_text(encoding="utf-8").splitlines())
+        for line in self._cases()["reported"]:
+            found = self._findings_for(line)
+            assert len(found) == 1, (
                 f"missed a stale repository reference: {line!r}")
+            # And on the appended line, not somewhere in the file's own text:
+            # a finding reported against line 1 would pass the count and mean
+            # the case under test was never reached.
+            reported_at = int(found[0].split(" ", 1)[0].rsplit(":", 1)[1])
+            assert reported_at > own_lines, (
+                f"reported line {reported_at} of a {own_lines}-line file, "
+                f"which is its own content rather than {line!r}")
 
 
 class TestTheCliHelpIsCleanText:

--- a/workspace/docs/release-manifest.json
+++ b/workspace/docs/release-manifest.json
@@ -72,7 +72,7 @@
       {
         "name": "@deepwatch/cli",
         "version": "0.1.1",
-        "integrity": "sha256:0e0602f6f8dd7052c4546d3dbf9f68cad46084524a423f3c4b11b329b902b1eb",
+        "integrity": "sha256:94226ab23845cdb88294f0ca27ef93780d33ba484a2654d353f41388d9810873",
         "sourceFiles": 12
       },
       {
@@ -189,7 +189,7 @@
       "creators": [
         "Tool: watch-gen-release-manifest"
       ],
-      "created": "2026-09-07T11:47:30Z"
+      "created": "2026-09-07T18:32:41Z"
     },
     "packages": [
       {
@@ -252,7 +252,7 @@
         "checksums": [
           {
             "algorithm": "SHA256",
-            "checksumValue": "0e0602f6f8dd7052c4546d3dbf9f68cad46084524a423f3c4b11b329b902b1eb"
+            "checksumValue": "94226ab23845cdb88294f0ca27ef93780d33ba484a2654d353f41388d9810873"
           }
         ]
       },

--- a/workspace/packages/watch/cli/src/setup.ts
+++ b/workspace/packages/watch/cli/src/setup.ts
@@ -67,7 +67,9 @@ import {
 } from './lib/provision.js'
 import type { ManagedPackage, ManagedPlan, SourceMode } from './lib/provision.js'
 import { deepwatchHome, dshHome, profileName, watchCoreBin } from './lib/paths.js'
-import { BUNDLE_PACKAGE, BUNDLE_VERSION, HARNESS_VERSION, VERSION } from './version.js'
+import {
+  BUNDLE_PACKAGE, BUNDLE_VERSION, HARNESS_REGISTRY, HARNESS_VERSION, VERSION,
+} from './version.js'
 
 /** How long a profile operation may take before it is a hang rather than work. */
 const PROFILE_TIMEOUT_MS = 10 * 60 * 1000
@@ -357,8 +359,17 @@ export async function runSetup(invocation: Invocation): Promise<number> {
       // sometimes pasted, and a maintainer's absolute path is not this
       // product's to publish.
       resolvedFrom: 'the managed DeepWatch runtime',
-      registryRequests: 'none — every DeepWatch package came from the runtime\'s own '
-        + 'verified copies',
+      // Where the DeepWatch packages actually came from, not a sentence written
+      // when only one answer was possible. This said "none — every DeepWatch
+      // package came from the runtime's own verified copies" unconditionally,
+      // which is true of an --artifacts install and false of the registry
+      // install that is now the default. No request count is claimed either
+      // way: nothing here counts them, and a number nobody measured is worse
+      // than the mode, which is recorded.
+      deepwatchPackagesFrom: source.mode === 'local-artifacts'
+        ? 'verified local tarballs, copied into the runtime and installed from the copies'
+        : `the registry (${HARNESS_REGISTRY}), by name at ${BUNDLE_VERSION}, checked by npm `
+          + 'against each package\'s published integrity',
       // Recorded as a fact about this machine, not as a URL to keep: the probe
       // asked the operating system for a port and stopped the server again.
       boot: composition.servedFrom === undefined

--- a/workspace/scripts/qa-acceptance-local.mjs
+++ b/workspace/scripts/qa-acceptance-local.mjs
@@ -221,13 +221,17 @@ try {
   const receipt = join(HOME, 'harness', 'deepwatch-install-receipt.json')
   const installed = existsSync(receipt)
     ? JSON.parse(readFileSync(receipt, 'utf8')) : null
+  // Both receipts have to agree, and both now say where the packages came from
+  // rather than asserting a request count nothing measured. The composition
+  // receipt used to carry a fixed sentence beginning "none", which was true of
+  // this path and false of a registry install.
   claim('AL-01 the packages came from sealed local artifacts, not a registry',
     installed?.deepwatchSource === 'local-artifacts'
-      && composed?.registryRequests?.startsWith('none') === true,
+      && composed?.deepwatchPackagesFrom?.startsWith('verified local tarballs') === true,
     { source: installed?.deepwatchSource ?? null,
       origin: installed?.deepwatchArtifactOrigin ?? null,
       deepwatchPackages: installed?.deepwatchPackages?.length ?? 0,
-      registryRequests: composed?.registryRequests ?? null })
+      packagesFrom: composed?.deepwatchPackagesFrom ?? null })
 
   // ── 2. it starts, and it starts without a provider ─────────────────────────
   const readiness = await rpc('watchQuery/routeReadiness', { args: { request: {

--- a/workspace/scripts/verify-packed-exec.mjs
+++ b/workspace/scripts/verify-packed-exec.mjs
@@ -297,39 +297,65 @@ ERR<${result.stderr.slice(0, 300)}>
     }
   })
 
-  // Setup, refused for want of an artifact directory. Nothing under
-  // `@deepwatch` is published, so there is no registry answer to fall back to
-  // and the product says so rather than asking for a scope that does not exist.
-  expect('setup with no artifacts', run(process.execPath, [cli, 'setup', '--yes'], withHome),
-    result => {
-      if (result.code === 0) return 'reported success with nowhere to get the packages from'
-      const said = result.stdout + result.stderr
-      if (!said.includes('--artifacts')) return 'did not say what was missing'
-      if (existsSync(join(home, 'harness'))) return 'wrote where the runtime goes'
-      return null
-    })
+  // Each setup case gets a home of its own.
+  //
+  // They shared one until the scope was published. `setup --yes` with no
+  // artifacts used to refuse, so nothing was ever built and the later cases
+  // ran against an empty home by luck. It installs from the registry now, and
+  // a shared home meant every case after the first was judging a machine that
+  // already had a runtime on it -- consent and offline both behave differently
+  // once one exists.
+  const setupHome = label => {
+    const dir = join(room('deepwatch-setup-'), label)
+    mkdirSync(dir, { recursive: true })
+    return { cwd: project, env: { ...process.env, DEEPWATCH_HOME: dir } }
+  }
 
-  // Setup, refused. Non-interactive and without `--yes`, so the plan is shown
-  // and nothing is fetched — the case that would otherwise install five
-  // hundred packages inside somebody's CI.
-  expect('setup without consent',
-    run(process.execPath, [cli, 'setup', '--artifacts', ARTIFACTS], withHome), result => {
+  // No artifacts, no consent: the registry plan is printed and nothing is
+  // fetched. This is the path a new user takes, and the one that would
+  // otherwise install five hundred packages inside somebody's CI.
+  const registryPlan = setupHome('registry-plan')
+  expect('setup with no artifacts, no consent',
+    run(process.execPath, [cli, 'setup'], registryPlan), result => {
       if (result.code === 0) return 'reported success without installing anything'
       const said = result.stdout + result.stderr
       if (!said.includes('registry.npmjs.org')) return 'did not name the registry first'
-      if (!said.includes('@deepseek-ai/dsh')) return 'did not name the package first'
-      if (!said.includes(ARTIFACTS)) return 'did not name where the local packages come from'
-      if (existsSync(join(home, 'harness', 'node_modules'))) return 'downloaded something anyway'
+      if (!said.includes('@deepseek-ai/dsh')) return 'did not name the Harness first'
+      if (!/from the registry/.test(said)) return 'did not say where the DeepWatch packages come from'
+      if (!said.includes('--yes')) return 'did not say how to agree'
+      if (existsSync(join(registryPlan.env.DEEPWATCH_HOME, 'harness', 'node_modules'))) {
+        return 'downloaded something nobody agreed to'
+      }
       return null
     })
 
-  // Setup, refused for a different reason: offline wins over consent.
+  // The sealed-artifact path is a different mode, and it names the directory
+  // it would install from. Still no consent, so still nothing fetched.
+  const artifactPlan = setupHome('artifact-plan')
+  expect('setup --artifacts without consent',
+    run(process.execPath, [cli, 'setup', '--artifacts', ARTIFACTS], artifactPlan), result => {
+      if (result.code === 0) return 'reported success without installing anything'
+      const said = result.stdout + result.stderr
+      if (!said.includes('registry.npmjs.org')) return 'did not name the registry first'
+      if (!said.includes(ARTIFACTS)) return 'did not name where the local packages come from'
+      if (!/verified local artifacts/.test(said)) return 'did not distinguish the artifact mode'
+      if (existsSync(join(artifactPlan.env.DEEPWATCH_HOME, 'harness', 'node_modules'))) {
+        return 'downloaded something anyway'
+      }
+      return null
+    })
+
+  // Offline wins over consent, in a home of its own so the refusal is about
+  // the policy rather than about a runtime that happens to be there already.
+  const offline = setupHome('offline')
   expect('setup --offline --yes',
-    run(process.execPath, [cli, 'setup', '--offline', '--yes'], withHome),
+    run(process.execPath, [cli, 'setup', '--offline', '--yes'], offline),
     result => {
       if (result.code === 0) return 'reported success while offline'
       if (!/offline/i.test(result.stdout + result.stderr)) return 'did not say why it refused'
-      if (existsSync(join(home, 'harness', 'node_modules'))) return 'downloaded something anyway'
+      if (existsSync(join(offline.env.DEEPWATCH_HOME, 'harness', 'node_modules'))) {
+        return 'downloaded something anyway'
+      }
       return null
     })
 

--- a/workspace/scripts/verify-packed-exec.mjs
+++ b/workspace/scripts/verify-packed-exec.mjs
@@ -2,21 +2,27 @@
 /**
  * Run `deepwatch` the ways people actually run it.
  *
- * **This is not a test of `npx @deepwatch/cli`.** Nothing is published, so
- * there is no registry to fetch from and no claim to make about one. What this
- * does is *packed-artifact equivalent* testing: the same tarball a publish
- * would upload, installed locally, and then invoked through each runner's own
- * resolution path — `npm exec`, `npx` against an existing install, `pnpm exec`,
- * and a real global install into a prefix this script owns.
+ * **This is not a test of `npx @deepwatch/cli` from the registry.** The
+ * registry serves the last release; this gate is about the candidate, which
+ * has not been published and, if it fails here, will not be. So what it does
+ * is *packed-artifact equivalent* testing: the exact tarballs a publish of
+ * this commit would upload, installed locally, and then invoked through each
+ * runner's own resolution path — `npm exec`, `npx` against an existing
+ * install, `pnpm exec`, and a real global install into a prefix this script
+ * owns. The published equivalent runs after a publish, in the `smoke` job of
+ * release-deepwatch.yml, pinned to the version that was just uploaded.
  *
  * Each runner finds a binary differently, and each has broken this before: a
  * `bin` field that points at a file `files` does not ship, a shim that cannot
  * find its own package, a global install with no dependency closure.
  *
  * The subcommands exercised here are the ones that are safe to exercise
- * anywhere: version, help, doctor, and both sides of setup's consent gate.
- * Booting the Web app and the desktop shell needs a real Harness, and belongs
- * to the QA pass that has one.
+ * anywhere: version, help, doctor, and every side of setup's consent gate
+ * that refuses. A setup allowed to proceed fetches a Harness and its closure,
+ * so the successful install belongs to a gate with a machine to do it on —
+ * `browser-e2e` in workspace-ci.yml composes a profile from these same
+ * artifacts and boots it. Booting the desktop shell needs a real Harness too,
+ * and belongs to the QA pass that has one.
  *
  * Usage:
  *   node scripts/verify-packed-exec.mjs
@@ -208,9 +214,10 @@ ERR<${result.stderr.slice(0, 300)}>
   //
   // Handed twenty sibling tarballs, npm satisfies `@deepwatch/dsh-bundle` from
   // the one on its own command line. pnpm does not: it resolves every
-  // transitive range by name against the registry, and an unpublished scope is
-  // a 404 there. That is a fact about these packages not being published, not
-  // a defect in them — and it means the honest pnpm equivalent is a workspace
+  // transitive range by name against the registry, where the candidate's
+  // version does not exist yet — a 404 for exactly the version under test,
+  // whatever else the scope already serves. That is a fact about a candidate,
+  // not a defect in it, and it means the honest pnpm equivalent is a workspace
   // of the *unpacked* tarballs, where pnpm links them by version and its own
   // `exec` resolution is what gets exercised.
   //
@@ -380,6 +387,7 @@ if (report.problems.length > 0) {
   process.exitCode = 1
 } else {
   process.stdout.write(
-    `\npacked-exec: ${report.ran.length} invocations, all from packed artifacts `
-    + '(nothing is published, so no registry install was tested)\n')
+    `\npacked-exec: ${report.ran.length} invocations, all from this commit's `
+    + 'packed artifacts (a published version is smoked after it is published, '
+    + 'not here)\n')
 }

--- a/workspace/scripts/verify-release-surface.mjs
+++ b/workspace/scripts/verify-release-surface.mjs
@@ -96,9 +96,15 @@ function scan(label, text, exemptKey = label) {
       let hit = null
       while ((hit = all.exec(lines[i])) !== null) {
         if (hit[0].length === 0) { all.lastIndex += 1; continue }
-        const before = lines[i].slice(0, hit.index + hit[0].indexOf('watch') + 0)
+        // The text before this occurrence, and nothing else — the same window
+        // tests/test_release_surface.py uses, so an exemption cannot mean two
+        // things. A second, wider window was tried alongside it, computed
+        // from `indexOf('watch')` *inside* the match: 0 for the one rule that
+        // has a scoped exemption, and -1 for every other, which slides the
+        // boundary a character to the left. Two answers to one question, of
+        // which this is the question.
         const prefix = lines[i].slice(0, hit.index)
-        if (allowed.some(re => re.test(prefix) || re.test(before))) continue
+        if (allowed.some(re => re.test(prefix))) continue
         found = hit
         break
       }

--- a/workspace/scripts/verify-release-surface.mjs
+++ b/workspace/scripts/verify-release-surface.mjs
@@ -60,7 +60,23 @@ function globToRegExp(glob) {
 
 const INCLUDE = CONFIG.surfaces.include.map(globToRegExp)
 const EXCLUDE = CONFIG.surfaces.exclude.map(globToRegExp)
-const EXEMPT = new Set(CONFIG.exemptions.map(entry => `${entry.file}\u0000${entry.rule}`))
+/**
+ * Exemptions, keyed by file and rule.
+ *
+ * An entry without `contains` excuses the whole file, which is the blunt form
+ * and is what most of these need. An entry *with* `contains` excuses only the
+ * lines holding that text — so a file may carry one legitimate phrase a rule
+ * would otherwise flag without going blind to every other occurrence of it.
+ * `watch-workspace` is exactly that: a real profile row id, and also the name
+ * of a repository that does not exist.
+ */
+const EXEMPT = new Map()
+for (const entry of CONFIG.exemptions) {
+  const key = `${entry.file}\u0000${entry.rule}`
+  const scoped = EXEMPT.get(key)
+  if (entry.contains === undefined) EXEMPT.set(key, null)
+  else if (scoped !== null) EXEMPT.set(key, [...(scoped ?? []), entry.contains])
+}
 
 const findings = []
 
@@ -68,11 +84,14 @@ const findings = []
 function scan(label, text, exemptKey = label) {
   const lines = text.split(/\r?\n/)
   for (const rule of RULES) {
-    if (EXEMPT.has(`${exemptKey}\u0000${rule.id}`)) continue
+    const key = `${exemptKey}\u0000${rule.id}`
+    if (EXEMPT.has(key) && EXEMPT.get(key) === null) continue
+    const allowed = EXEMPT.get(key) ?? []
     for (let i = 0; i < lines.length; i += 1) {
       rule.re.lastIndex = 0
       const found = rule.re.exec(lines[i])
       if (found === null) continue
+      if (allowed.some(text_ => lines[i].includes(text_))) continue
       findings.push({
         file: label,
         line: i + 1,

--- a/workspace/scripts/verify-release-surface.mjs
+++ b/workspace/scripts/verify-release-surface.mjs
@@ -63,19 +63,21 @@ const EXCLUDE = CONFIG.surfaces.exclude.map(globToRegExp)
 /**
  * Exemptions, keyed by file and rule.
  *
- * An entry without `contains` excuses the whole file, which is the blunt form
- * and is what most of these need. An entry *with* `contains` excuses only the
- * lines holding that text — so a file may carry one legitimate phrase a rule
- * would otherwise flag without going blind to every other occurrence of it.
- * `watch-workspace` is exactly that: a real profile row id, and also the name
- * of a repository that does not exist.
+ * An entry without `precededBy` excuses the whole file, which is the blunt form
+ * and what most of these need. An entry *with* it excuses only the occurrences
+ * whose preceding text matches — one match at a time, not a whole line. That
+ * distinction matters where the flagged name is also a legitimate identifier:
+ * `watch-workspace` is a real profile row id *and* the name of a repository
+ * that does not exist, and both can appear on one line.
  */
 const EXEMPT = new Map()
 for (const entry of CONFIG.exemptions) {
   const key = `${entry.file}\u0000${entry.rule}`
   const scoped = EXEMPT.get(key)
-  if (entry.contains === undefined) EXEMPT.set(key, null)
-  else if (scoped !== null) EXEMPT.set(key, [...(scoped ?? []), entry.contains])
+  if (entry.precededBy === undefined) EXEMPT.set(key, null)
+  else if (scoped !== null) {
+    EXEMPT.set(key, [...(scoped ?? []), new RegExp(entry.precededBy)])
+  }
 }
 
 const findings = []
@@ -88,10 +90,19 @@ function scan(label, text, exemptKey = label) {
     if (EXEMPT.has(key) && EXEMPT.get(key) === null) continue
     const allowed = EXEMPT.get(key) ?? []
     for (let i = 0; i < lines.length; i += 1) {
-      rule.re.lastIndex = 0
-      const found = rule.re.exec(lines[i])
+      // Every occurrence on the line, so an exempt one does not hide the rest.
+      const all = new RegExp(rule.re.source, `${rule.re.flags.replace('g', '')}g`)
+      let found = null
+      let hit = null
+      while ((hit = all.exec(lines[i])) !== null) {
+        if (hit[0].length === 0) { all.lastIndex += 1; continue }
+        const before = lines[i].slice(0, hit.index + hit[0].indexOf('watch') + 0)
+        const prefix = lines[i].slice(0, hit.index)
+        if (allowed.some(re => re.test(prefix) || re.test(before))) continue
+        found = hit
+        break
+      }
       if (found === null) continue
-      if (allowed.some(text_ => lines[i].includes(text_))) continue
       findings.push({
         file: label,
         line: i + 1,

--- a/workspace/scripts/verify-release-surface.mjs
+++ b/workspace/scripts/verify-release-surface.mjs
@@ -182,7 +182,12 @@ function scanTarballs() {
       const text = execFileSync('tar', ['-xzOf', tarball, member], {
         cwd: ARTIFACTS, encoding: 'utf8', maxBuffer: 1 << 28,
       })
-      scan(`${tarball}:${member.replace(/^package\//, '')}`, text, member.replace(/^package\//, ''))
+      const inside = member.replace(/^package\//, '')
+      // Keyed by package, not by the bare member path: `README.md` alone would
+      // excuse the same file in all twenty tarballs. The version is stripped so
+      // an exemption written today still names the same package next release.
+      const pkg = tarball.replace(/-\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?\.tgz$/, '')
+      scan(`${tarball}:${inside}`, text, `${pkg}:${inside}`)
       files += 1
     }
   }

--- a/workspace/tests/release-surface.test.mjs
+++ b/workspace/tests/release-surface.test.mjs
@@ -144,6 +144,56 @@ describe('the gate fails on a file that breaks a rule', () => {
   })
 })
 
+describe('a scoped exemption excuses a line, never a file', () => {
+  // The exemption exists because `watch-workspace` is both a real profile row
+  // id and the name of a repository that does not exist. Excusing the whole
+  // file would switch the rule off exactly where the confusing name lives --
+  // so the excuse is scoped to the row, and this proves the rest of that same
+  // file is still scanned.
+  const EXEMPTED = join(REPO, 'workspace', 'packages', 'watch', 'workspace', 'README.md')
+
+  test('a genuine stale reference in the exempted file is still reported', () => {
+    const original = readFileSync(EXEMPTED, 'utf8')
+    // The row this file is allowed to contain, unchanged, plus a real one.
+    assert.ok(original.includes('id: watch-workspace'),
+      'the fixture assumes this file carries the allowed profile row')
+    let output
+    let status = 0
+    try {
+      writeFileSync(EXEMPTED,
+        `${original}\n\nClone watch-workspace and run pnpm install.\n`, 'utf8')
+      try {
+        output = execFileSync(
+          process.execPath, [join(ROOT, 'scripts', 'verify-release-surface.mjs'), '--json'],
+          { cwd: ROOT, encoding: 'utf8' })
+      } catch (error) {
+        status = error.status
+        output = error.stdout
+      }
+    } finally {
+      writeFileSync(EXEMPTED, original, 'utf8')
+    }
+
+    assert.equal(status, 1, 'a stale repository reference passed inside an exempted file')
+    const result = JSON.parse(output)
+    const hits = result.findings.filter(finding =>
+      finding.rule === 'phantom-repository'
+      && finding.file.endsWith('packages/watch/workspace/README.md'))
+    assert.equal(hits.length, 1,
+      `the planted reference was not reported: ${JSON.stringify(result.findings)}`)
+  })
+
+  test('and the allowed row in that same file is still not reported', () => {
+    // The other half: with nothing planted, the file is clean even though it
+    // contains the string the rule matches.
+    const output = execFileSync(
+      process.execPath, [join(ROOT, 'scripts', 'verify-release-surface.mjs'), '--json'],
+      { cwd: ROOT, encoding: 'utf8' })
+    const result = JSON.parse(output)
+    assert.equal(result.ok, true, JSON.stringify(result.findings, null, 2))
+  })
+})
+
 describe('the exemptions stay narrow', () => {
   test('each names one exact file, one rule, and a reason', () => {
     for (const exemption of CONFIG.exemptions) {

--- a/workspace/tests/release-surface.test.mjs
+++ b/workspace/tests/release-surface.test.mjs
@@ -22,6 +22,8 @@ import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import { publishOrder } from '../scripts/publish-order.mjs'
+
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
 const REPO = join(ROOT, '..')
 const CONFIG = JSON.parse(readFileSync(join(REPO, 'release-surface-rules.json'), 'utf8'))
@@ -208,7 +210,19 @@ describe('the exemptions stay narrow', () => {
     const tracked = new Set(
       execFileSync('git', ['ls-files'], { cwd: REPO, encoding: 'utf8', maxBuffer: 1 << 28 })
         .split('\n').map(line => line.trim()).filter(line => line !== ''))
+    // Two shapes. A repository path must be tracked. A `package:member` key
+    // scopes an exemption to a file *inside* a packed tarball, where the repo
+    // path does not exist -- so it is checked against the packages this
+    // workspace actually publishes instead, which catches a typo just as well.
+    const published = new Set(publishOrder()
+      .map(entry => entry.name.replace('@', '').replace('/', '-')))
     for (const exemption of CONFIG.exemptions) {
+      if (exemption.file.includes(':')) {
+        const [pkg] = exemption.file.split(':')
+        assert.ok(published.has(pkg),
+          `${exemption.file} names a package this workspace does not publish`)
+        continue
+      }
       assert.ok(tracked.has(exemption.file),
         `${exemption.file} is exempt and not in the repository`)
     }

--- a/workspace/tests/release-surface.test.mjs
+++ b/workspace/tests/release-surface.test.mjs
@@ -23,10 +23,37 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { publishOrder } from '../scripts/publish-order.mjs'
+import { resolveNpm } from '../scripts/lib/process.mjs'
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
 const REPO = join(ROOT, '..')
 const CONFIG = JSON.parse(readFileSync(join(REPO, 'release-surface-rules.json'), 'utf8'))
+
+/**
+ * What a publish of one package would actually upload, by member path.
+ *
+ * npm is asked rather than the filesystem, because `files` is what decides
+ * and a README present on disk is not a README that ships. `--dry-run`
+ * uploads nothing; it lists.
+ *
+ * Cached, because the exemption check would otherwise pack the same package
+ * once per assertion.
+ */
+const packed = new Map()
+function packedMembers(dir) {
+  if (packed.has(dir)) return packed.get(dir)
+  const npm = resolveNpm()
+  assert.ok(npm !== null, 'no npm this tooling can run was found')
+  const listed = execFileSync(
+    npm.command, [...npm.prefix, 'pack', '--dry-run', '--json'],
+    { cwd: join(ROOT, dir), encoding: 'utf8', maxBuffer: 1 << 28 })
+  // npm prints the tarball name on stdout before the JSON in some versions,
+  // so the array is taken from the first `[` rather than from position zero.
+  const parsed = JSON.parse(listed.slice(listed.indexOf('[')))
+  const members = new Set(parsed[0].files.map(file => file.path))
+  packed.set(dir, members)
+  return members
+}
 
 /** Text that each rule must catch, and text it must leave alone. */
 const CONTROLS = {
@@ -212,15 +239,24 @@ describe('the exemptions stay narrow', () => {
         .split('\n').map(line => line.trim()).filter(line => line !== ''))
     // Two shapes. A repository path must be tracked. A `package:member` key
     // scopes an exemption to a file *inside* a packed tarball, where the repo
-    // path does not exist -- so it is checked against the packages this
-    // workspace actually publishes instead, which catches a typo just as well.
-    const published = new Set(publishOrder()
-      .map(entry => entry.name.replace('@', '').replace('/', '-')))
+    // path does not exist -- so the package and the member are checked
+    // separately, against what a publish would actually upload.
+    const byTarballName = new Map(publishOrder()
+      .map(entry => [entry.name.replace('@', '').replace('/', '-'), entry]))
     for (const exemption of CONFIG.exemptions) {
       if (exemption.file.includes(':')) {
-        const [pkg] = exemption.file.split(':')
-        assert.ok(published.has(pkg),
+        const [pkg, member] = exemption.file.split(':')
+        const entry = byTarballName.get(pkg)
+        assert.ok(entry !== undefined,
           `${exemption.file} names a package this workspace does not publish`)
+        // The package name alone was the whole check, so an exemption could
+        // name a member that no longer ships -- or never did -- and still
+        // read as verified. `files` decides what a tarball carries and the
+        // disk does not, so the question goes to npm.
+        assert.ok(packedMembers(entry.dir).has(member),
+          `${exemption.file} excuses a file @${entry.name} does not ship: `
+          + `npm pack lists ${[...packedMembers(entry.dir)].length} members `
+          + 'and none of them is that one')
         continue
       }
       assert.ok(tracked.has(exemption.file),

--- a/workspace/tests/release-surface.test.mjs
+++ b/workspace/tests/release-surface.test.mjs
@@ -175,6 +175,27 @@ describe('the exemptions stay narrow', () => {
     }
   })
 
+  test('the shared fixtures hold in this engine too', () => {
+    // One fixture file, read by this suite and by tests/test_release_surface.py.
+    // The rule shipped broken twice -- once matching nothing in Python, once
+    // missing Markdown and `repository:` forms -- because each engine had its
+    // own idea of the cases. A shared file makes that impossible.
+    const fixtures = JSON.parse(
+      readFileSync(join(REPO, 'release-surface-fixtures.json'), 'utf8'))
+    for (const [id, cases] of Object.entries(fixtures)) {
+      if (id.startsWith('$')) continue
+      const rule = rules.get(id)
+      assert.ok(rule !== undefined, `${id} has fixtures but is not a rule`)
+      const pattern = new RegExp(rule.pattern)
+      for (const text of cases.catches) {
+        assert.ok(pattern.test(text), `${id} must catch: ${text}`)
+      }
+      for (const text of cases.allows) {
+        assert.equal(pattern.test(text), false, `${id} must not fire on: ${text}`)
+      }
+    }
+  })
+
   test('phantom-repository names a repository, not a substring of the product', () => {
     // Unanchored, `watch-workspace` also matches `deepwatch-workspace`, so a
     // README heading called "The DeepWatch Workspace" was reported as naming a
@@ -184,21 +205,20 @@ describe('the exemptions stay narrow', () => {
     const rule = CONFIG.rules.find(entry => entry.id === 'phantom-repository')
     const fires = text => new RegExp(rule.pattern, 'g').test(text)
 
-    for (const named of [
-      'oxbshw/watch-workspace',
-      'clone the watch-workspace repository',
-      'see watch-workspace.',
-    ]) assert.ok(fires(named), `${named} names the repository this rule refuses`)
-
-    for (const fine of [
-      '#the-deepwatch-workspace',
-      '@deepwatch/dsh-workspace',
-      'deepwatch-workspace/thing',
-      // The profile row that mounts the package. It appears in every example
-      // showing how to compose the workspace half, and it is an identifier in
-      // somebody's YAML rather than a repository anybody could clone.
-      "- id: watch-workspace",
-      "  id: watch-workspace",
-    ]) assert.ok(!fires(fine), `${fine} is not a repository name`)
+    const fixtures = JSON.parse(
+      readFileSync(join(REPO, 'release-surface-fixtures.json'), 'utf8'))
+    for (const named of fixtures['phantom-repository'].catches) {
+      assert.ok(fires(named), `${named} names the repository this rule refuses`)
+    }
+    for (const fine of fixtures['phantom-repository'].allows) {
+      assert.ok(!fires(fine), `${fine} is not a repository name`)
+    }
+    // The row id cannot be separated from a reference by pattern alone, so it
+    // is handled by a per-file exemption rather than by a cleverer regex.
+    assert.ok(fires('- id: watch-workspace'),
+      'the pattern is deliberately simple; the row id is exempted by file')
+    assert.ok(CONFIG.exemptions.some(e => e.rule === 'phantom-repository'
+      && e.file.endsWith('packages/watch/workspace/README.md')),
+      'the file carrying the row must hold the exemption')
   })
 })

--- a/workspace/tests/release-surface.test.mjs
+++ b/workspace/tests/release-surface.test.mjs
@@ -144,53 +144,50 @@ describe('the gate fails on a file that breaks a rule', () => {
   })
 })
 
-describe('a scoped exemption excuses a line, never a file', () => {
-  // The exemption exists because `watch-workspace` is both a real profile row
-  // id and the name of a repository that does not exist. Excusing the whole
-  // file would switch the rule off exactly where the confusing name lives --
-  // so the excuse is scoped to the row, and this proves the rest of that same
-  // file is still scanned.
+describe('a scoped exemption excuses one occurrence, never a line or a file', () => {
+  // `watch-workspace` is a real profile row id *and* the name of a repository
+  // that does not exist. A whole-file exemption would switch the rule off
+  // exactly where the confusing name lives; a whole-line one would hide a
+  // stale reference sitting beside the row. The cases are shared with
+  // tests/test_release_surface.py so both scanners are held to them.
   const EXEMPTED = join(REPO, 'workspace', 'packages', 'watch', 'workspace', 'README.md')
+  const CASES = JSON.parse(
+    readFileSync(join(REPO, 'release-surface-fixtures.json'), 'utf8'),
+  )['$exemptions']['phantom-repository']
 
-  test('a genuine stale reference in the exempted file is still reported', () => {
+  /** Append one line to the exempted file and return its phantom findings. */
+  function findingsFor(line) {
     const original = readFileSync(EXEMPTED, 'utf8')
-    // The row this file is allowed to contain, unchanged, plus a real one.
-    assert.ok(original.includes('id: watch-workspace'),
-      'the fixture assumes this file carries the allowed profile row')
-    let output
-    let status = 0
     try {
-      writeFileSync(EXEMPTED,
-        `${original}\n\nClone watch-workspace and run pnpm install.\n`, 'utf8')
+      writeFileSync(EXEMPTED, `${original}\n${line}\n`, 'utf8')
       try {
-        output = execFileSync(
+        execFileSync(
           process.execPath, [join(ROOT, 'scripts', 'verify-release-surface.mjs'), '--json'],
           { cwd: ROOT, encoding: 'utf8' })
+        return []
       } catch (error) {
-        status = error.status
-        output = error.stdout
+        return JSON.parse(error.stdout).findings
+          .filter(finding => finding.rule === 'phantom-repository')
       }
     } finally {
       writeFileSync(EXEMPTED, original, 'utf8')
     }
+  }
 
-    assert.equal(status, 1, 'a stale repository reference passed inside an exempted file')
-    const result = JSON.parse(output)
-    const hits = result.findings.filter(finding =>
-      finding.rule === 'phantom-repository'
-      && finding.file.endsWith('packages/watch/workspace/README.md'))
-    assert.equal(hits.length, 1,
-      `the planted reference was not reported: ${JSON.stringify(result.findings)}`)
+  test('the allowed row is not reported, however it is spaced', () => {
+    // Two spaces and a tab both used to be rejected, because the exemption
+    // matched one exact string.
+    for (const line of CASES.clean) {
+      assert.deepEqual(findingsFor(line), [],
+        `the scanner reported a legitimate profile row: ${JSON.stringify(line)}`)
+    }
   })
 
-  test('and the allowed row in that same file is still not reported', () => {
-    // The other half: with nothing planted, the file is clean even though it
-    // contains the string the rule matches.
-    const output = execFileSync(
-      process.execPath, [join(ROOT, 'scripts', 'verify-release-surface.mjs'), '--json'],
-      { cwd: ROOT, encoding: 'utf8' })
-    const result = JSON.parse(output)
-    assert.equal(result.ok, true, JSON.stringify(result.findings, null, 2))
+  test('a genuine stale reference is reported, including beside the row', () => {
+    for (const line of CASES.reported) {
+      assert.equal(findingsFor(line).length, 1,
+        `the scanner missed a stale repository reference: ${JSON.stringify(line)}`)
+    }
   })
 })
 

--- a/workspace/tests/release-workflow.test.mjs
+++ b/workspace/tests/release-workflow.test.mjs
@@ -518,3 +518,56 @@ test('the required workspace result includes the real browser journey', () => {
   const required = job(workflow, 'workspace-required')
   assert.match(required, /browser-e2e/)
 })
+
+describe('the published smoke retries a flake and never a finding', () => {
+  // A published smoke is the one check that runs against something nobody can
+  // take back, so it has to be believable in both directions. Retrying
+  // everything makes a broken publish look slow instead of broken; retrying
+  // nothing makes a CDN that is thirty seconds behind look like a broken
+  // publish. Each smoke retries the fetch and asserts the version outside the
+  // loop, and each names the failures it will not retry.
+  const SMOKES = [
+    ['release-deepwatch.yml', DEEPWATCH, 'npx-err.log',
+      ['EINTEGRITY', 'ENEEDAUTH', 'E401', 'E403']],
+    ['post-publish.yml', readFileSync(join(WORKFLOWS, 'post-publish.yml'), 'utf8'),
+      'uvx-err.log', ['hash mismatch', 'Failed to build', 'No solution found']],
+  ]
+
+  for (const [name, workflow, log, fatal] of SMOKES) {
+    test(`${name} bounds its retries and backs off`, () => {
+      assert.match(workflow, /attempt=0\s*\n\s*delay=5/,
+        `${name} does not start a bounded retry`)
+      assert.match(workflow, /delay=\$\(\(delay \* 2\)\)/,
+        `${name} retries without backing off`)
+      assert.match(workflow, /if \[ "\$attempt" -ge 4 \]/,
+        `${name} has no ceiling on its retries`)
+    })
+
+    test(`${name} keeps a failure a retry cannot fix visible`, () => {
+      for (const marker of fatal) {
+        assert.ok(workflow.includes(marker),
+          `${name} would retry ${marker}, which says the same thing every time`)
+      }
+      assert.match(workflow, /a reason a retry cannot fix/,
+        `${name} does not distinguish the two kinds of failure`)
+    })
+
+    test(`${name} reports what actually went wrong`, () => {
+      // `stderr` discarded is how a CI failure takes three runs to characterise.
+      assert.ok(workflow.includes(`2>${log}`),
+        `${name} does not capture the error stream`)
+      assert.ok(workflow.includes(`cat ${log}`),
+        `${name} captures the error stream and never prints it`)
+      assert.ok(workflow.includes(`tail -n 20 ${log}`),
+        `${name} says nothing between attempts`)
+    })
+
+    test(`${name} asserts the version outside the retry loop`, () => {
+      // A package that installs and reports the wrong version is a finding.
+      // Retrying it would eventually report the same wrong version, slower.
+      const afterLoop = workflow.split('done\n').slice(1).join('done\n')
+      assert.match(afterLoop, /test "\$\{?reported\}?" = "\$\{?(version|requested)\}?"/,
+        `${name} asserts the version somewhere a retry could paper over`)
+    })
+  }
+})


### PR DESCRIPTION
Two findings from running the published 0.1.1 product against a real hosted
model, plus the scoping fix a review of the first commit asked for.

## `phantom-repository` was wrong in three directions

Verified before fixing, against the rule as shipped:

| case | expected | before |
|---|---|---|
| a Markdown reference in backticks | fires | **missed** |
| `repository: watch-workspace` | fires | **missed** |
| a profile row with two spaces after the colon | silent | **fired** |

The cause was my own earlier narrowing: a lookbehind, which
`tests/test_release_surface.py` bans from this table outright because both
engines read it and a one-engine construct silently matches nothing on the
other side.

It goes back to the simple bounded name, which already cannot match inside
`deepwatch-workspace` — both sides of that boundary are word characters, so
the anchor was never the problem.

**`release-surface-fixtures.json`** is new: 8 positive and 5 negative cases,
read by the Node suite *and* the Python suite. A rule can no longer be green in
one engine and blind in the other, which is how this shipped broken twice.

## The exemption is scoped to a line, not a file

The first commit excused two whole files, because each carries the
`watch-workspace` profile row. That switches the rule off exactly where the
confusing name lives — a real stale reference would have passed unnoticed in
the file most likely to contain one.

An exemption may now carry `contains`: without it the whole file is excused,
with it only matching lines are skipped. Two tests plant into the **real**
exempted file and restore it afterwards:

* a genuine `Clone watch-workspace and run pnpm install.` **is reported**;
* with nothing planted, the allowed row in that same file **is not**.

## The install receipt claimed local copies after a registry install

`registryRequests` was hardcoded to *"none — every DeepWatch package came from
the runtime's own verified copies"*: true of `--artifacts`, false of the
registry install that is now the default. It is now `deepwatchPackagesFrom`,
recording the mode that actually ran. **No request count is invented** —
nothing counts them, and the mode is the honest fact. `qa-acceptance-local.mjs`
AL-01 reads the real field and still asserts the artifacts path it exists to
cover.

---

Node 21 pass · Python 22 pass · release-surface gate clean · build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
