### PR TITLE
ci: stop the suite skipping tests nobody can see

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,21 @@ jobs:
       - name: Generate the video-backend fixtures
         run: uv run python benchmarks/video_backends/make_fixtures.py
 
+      # `app/` carries axe-core and the ext-apps SDK, and two surface suites
+      # gate on them being installed. Nothing in this job had ever installed
+      # them, so the accessibility tests skipped on every run this workflow has
+      # had -- an accessibility suite that never executes is worse than none,
+      # because the row is there and it is reassuring.
+      - name: Node for the app fixtures
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22.19.0'
+          cache: npm
+          cache-dependency-path: app/package-lock.json
+
+      - name: Install the app's test dependencies
+        run: npm ci --prefix app
+
       # `pipefail` explicitly. GitHub's `shell: bash` sets it, and relying on
       # that would mean a pipeline whose exit status is `tee`'s -- a suite that
       # failed would report success, which is the one outcome this job may

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,9 +123,13 @@ jobs:
       - uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.python }}
+      # `espeak-ng` alongside ffmpeg because the fixture generator needs a system
+      # voice for the speech fixture. Without one it still renders the visual
+      # fixture and says it skipped the other, which would leave half the
+      # video-backend group gated on a package that costs a few hundred KB.
       - name: Install ffmpeg (Linux)
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg espeak-ng
       - name: Install ffmpeg (Windows)
         if: runner.os == 'Windows'
         run: choco install ffmpeg -y --no-progress
@@ -151,13 +155,35 @@ jobs:
       - name: Install Playwright browser + recording ffmpeg (Windows)
         if: runner.os == 'Windows'
         run: uv run playwright install chromium ffmpeg
+      # Generated, never committed -- they are 700 KB of rendered video and the
+      # generator is deterministic. Nineteen seconds here, and the whole
+      # `tests/bench/test_video_backend_*` group runs instead of skipping
+      # itself with "fixtures not generated". It skipped in every CI run this
+      # workflow has ever had, and the suite was green the entire time.
+      - name: Generate the video-backend fixtures
+        run: uv run python benchmarks/video_backends/make_fixtures.py
+
+      # `pipefail` explicitly. GitHub's `shell: bash` sets it, and relying on
+      # that would mean a pipeline whose exit status is `tee`'s -- a suite that
+      # failed would report success, which is the one outcome this job may
+      # never produce.
       - name: Run the offline suite
-        run: uv run pytest -q -m "not network" --timeout 300
+        run: |
+          set -eo pipefail
+          uv run pytest -q -m "not network" --timeout 300 -rs | tee pytest-report.txt
+        shell: bash
         env:
           # keep CI hermetic: no live vision backends, no cloud keys
           WATCHSKILL_VISION_CHEAP_PROVIDER: anthropic
           WATCHSKILL_VISION_STRONG_PROVIDER: anthropic
           FASTEMBED_CACHE_PATH: ci-model-cache
+
+      # A skip reads as a pass, so every one of them has to be a skip somebody
+      # signed off on. This fails the job on any other.
+      - name: No unaccounted-for skips
+        if: always()
+        shell: bash
+        run: uv run python scripts/check_skips.py pytest-report.txt
 
   # The always-present Core status, and the context branch protection requires.
   #

--- a/.github/workflows/workspace-ci.yml
+++ b/.github/workflows/workspace-ci.yml
@@ -496,6 +496,16 @@ jobs:
         working-directory: .
         shell: bash
         run: |
+          # `.venv`, which is where the repository's own tooling looks, and
+          # `.venv-core` for the Bridge suites that name it. They were only
+          # `.venv-core` before, and `workspace-canonical.test.mjs` asks
+          # `<root>/.venv` whether Core agrees with the launcher -- so five
+          # tests in the "Core agrees with the launcher" group skipped
+          # themselves on every platform cell with "no interpreter at
+          # .../.venv", in a job that had just installed Core one directory
+          # along. A skip reads as a pass.
+          uv venv .venv
+          uv pip install --python .venv --quiet .
           uv venv .venv-core
           uv pip install --python .venv-core --quiet .
           # `$GITHUB_WORKSPACE`, not `$PWD`. Bash on a Windows runner reports

--- a/scripts/check_skips.py
+++ b/scripts/check_skips.py
@@ -1,0 +1,105 @@
+"""Fail when a test skipped for a reason nobody signed off on.
+
+A skip reads as a pass. The suite was green while a whole module of
+video-backend tests ran nowhere, because its fixtures are generated and CI
+never generated them — and nothing said so, because `-q` prints one `s` and
+moves on.
+
+So CI now runs with `-rs`, and this reads the report it produces. Every skip
+must match one of the reasons below. Anything else fails the job, which is the
+only way a newly-skipped test becomes visible instead of becoming normal.
+
+    uv run pytest -q -m "not network" -rs | tee report.txt
+    uv run python scripts/check_skips.py report.txt
+
+The allowed set is deliberately small, and each entry says what would have to
+be true to remove it.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# Reasons a skip is legitimate on a hermetic runner, matched as substrings of
+# pytest's own reported reason.
+ALLOWED: dict[str, str] = {
+    # Platform gates. Each of these runs on the other half of the matrix, so
+    # nothing here goes untested anywhere -- it is tested where it applies.
+    "POSIX permission bits":
+        "runs on the Linux and macOS cells",
+    "Windows-only":
+        "runs on the Windows cells",
+    "requires Windows":
+        "runs on the Windows cells",
+
+    # Real-model gates that need weights, a server, or an accuracy this runner
+    # cannot be held to. Opening the ASR one was tried and reverted: with the
+    # weights cached and nothing else running, the recognition test still
+    # produced no speech events on the reference machine, so enabling it would
+    # trade a documented skip for a red build that says nothing about the
+    # change under test. It stays gated, and `docs/testing.md` says how to run
+    # it on a box that can.
+    "real-model ASR gate":
+        "run it locally with WATCHSKILL_TEST_REAL_ASR=1 - see docs/testing.md",
+    "faster-whisper-tiny is not cached":
+        "run it locally once with network access - see docs/testing.md",
+    "real-model live VLM gate":
+        "needs an interpreter with torch and a local VLM; run it on a box that has one",
+    "real-model VLM gate":
+        "needs a local Ollama vision model",
+    "no vision model reachable":
+        "needs a local Ollama vision model",
+    "real-model rendered gate":
+        "needs an interpreter with torch and a local VLM",
+    "real local-ASR recognition":
+        "same weights and the same gate as the ASR suite above",
+
+    # A resource gate that states its own threshold. It is a refusal to thrash
+    # a small runner, not a way of not running.
+    "governed browsers and needs about":
+        "the runner did not have the free memory the scenario states it needs",
+}
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        sys.stderr.write("usage: check_skips.py <pytest -rs report>\n")
+        return 2
+
+    report = Path(argv[1]).read_text(encoding="utf-8", errors="replace")
+    skipped = re.findall(r"^SKIPPED \[\d+\] (.+)$", report, flags=re.MULTILINE)
+
+    unexpected: list[str] = []
+    for line in skipped:
+        if not any(reason in line for reason in ALLOWED):
+            unexpected.append(line.strip())
+
+    counted: dict[str, int] = {}
+    for line in skipped:
+        for reason in ALLOWED:
+            if reason in line:
+                counted[reason] = counted.get(reason, 0) + 1
+                break
+
+    print(f"skips reported: {len(skipped)}")
+    for reason, count in sorted(counted.items()):
+        print(f"  {count:>3}  {reason} -- {ALLOWED[reason]}")
+
+    if unexpected:
+        print()
+        print(f"{len(unexpected)} skip(s) nobody accounted for:")
+        for line in unexpected:
+            print(f"  {line}")
+        print()
+        print("A skip reads as a pass. Either make the test run on this runner,")
+        print("or add the reason to ALLOWED in scripts/check_skips.py with a")
+        print("sentence saying where it does run.")
+        return 1
+
+    print("\nevery skip is one of the accounted-for gates")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/check_skips.py
+++ b/scripts/check_skips.py
@@ -59,6 +59,23 @@ ALLOWED: dict[str, str] = {
     # a small runner, not a way of not running.
     "governed browsers and needs about":
         "the runner did not have the free memory the scenario states it needs",
+    "the browser governor refused at the moment it decided":
+        "the runner did not have the free memory the governor requires",
+
+    # Windows-only capture, and the display it needs. `gdigrab` exists on one
+    # platform; the rest of this file needs a desktop session, which a hosted
+    # runner does not have. Both refuse rather than reporting an uncaptured
+    # window as a captured one.
+    "gdigrab window capture is implemented for Windows only":
+        "runs on the Windows cells",
+    "no interactive display":
+        "needs a desktop session; run it on a workstation, not a hosted runner",
+
+    # An inverted assertion: it checks that a contract requiring an assurance
+    # level is *refused* on a machine that cannot reach that level. A runner
+    # that can reach it has nothing to refuse, so there is nothing to assert.
+    "so a contract requiring it is not expected to be refused":
+        "asserts a refusal, and this machine has the capability to refuse over",
 }
 
 


### PR DESCRIPTION
A skip reads as a pass. Three groups of tests were skipping in CI and being
counted as green.

**The video-backend fixtures were never generated.**
`tests/bench/test_video_backend_realmedia.py` gates on
`benchmarks/video_backends/fixtures/visual_events.mp4`, which is generated and
gitignored, and no CI job had ever run the generator. Nineteen seconds. With
the fixtures present the bench group is 176 tests, 0 skipped, all passing.

**`espeak-ng` on Linux**, because the generator needs a system voice for the
speech fixture. Without one it renders the visual fixture, prints that it
skipped the other, and exits zero.

**The workspace `platform` job installed Core one directory along from where
the tests look.** It built `.venv-core`; `workspace-canonical.test.mjs` asks
`<root>/.venv` whether Core agrees with the launcher. Five tests in "Core
agrees with the launcher" skipped on every platform cell with *no interpreter
at .../.venv* — in a job that had just installed Core. It now builds both.

**And the general case.** pytest runs with `-rs`, and `scripts/check_skips.py`
fails the job on any skip whose reason is not on an accounted-for list, each
entry saying where that test runs instead. A test that starts skipping is now a
red build rather than a quieter green one. The pipeline sets `pipefail`
explicitly so the suite's exit status is pytest's and not `tee`'s.

The one gate deliberately left closed is the real-model ASR suite. Opening it
was tried: with the weights cached and nothing else running, the recognition
test still produced no speech events on the reference machine, so enabling it
would trade a documented skip for a red build that says nothing about the
change under test. Its reason is on the list, naming where to run it.

`manifest.json` is not touched. It is committed ground truth, regenerating it
produces different digests on every machine, and no test compares media digests
against it — so rewriting it from one laptop would be a change to evidence and
not to code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
